### PR TITLE
Overwrite region bug

### DIFF
--- a/amplify/backend/function/notifyRegionChanges/notifyRegionChanges-cloudformation-template.json
+++ b/amplify/backend/function/notifyRegionChanges/notifyRegionChanges-cloudformation-template.json
@@ -62,7 +62,7 @@
 				"Runtime": "nodejs10.x",
 				"Timeout": "25",
 				"Code": {
-					"S3Bucket": "amplify-kiyanaw-dev-02717-deployment",
+					"S3Bucket": "amplify-kiyanaw-prod-214643-deployment",
 					"S3Key": "amplify-builds/notifyRegionChanges-62687373386358766d62-build.zip"
 				}
 			}

--- a/amplify/backend/function/notifyRegionChanges/notifyRegionChanges-cloudformation-template.json
+++ b/amplify/backend/function/notifyRegionChanges/notifyRegionChanges-cloudformation-template.json
@@ -62,7 +62,7 @@
 				"Runtime": "nodejs10.x",
 				"Timeout": "25",
 				"Code": {
-					"S3Bucket": "amplify-kiyanaw-prod-214643-deployment",
+					"S3Bucket": "amplify-kiyanaw-dev-02717-deployment",
 					"S3Key": "amplify-builds/notifyRegionChanges-62687373386358766d62-build.zip"
 				}
 			}

--- a/src/components/transcribe/IssuesForm.vue
+++ b/src/components/transcribe/IssuesForm.vue
@@ -87,9 +87,9 @@
               small
               outlined
               color="red"
+              data-test="deleteIssueButton"
               @click="onDeleteIssue"
               :disabled="!user"
-              data-test="deleteIssueButton"
             >
               <v-icon left>mdi-delete-circle </v-icon>
               <!-- <span v-if="!selectedIssue.resolved">Delete</span> -->

--- a/src/components/transcribe/IssuesForm.vue
+++ b/src/components/transcribe/IssuesForm.vue
@@ -89,6 +89,7 @@
               color="red"
               @click="onDeleteIssue"
               :disabled="!user"
+              data-test="deleteIssueButton"
             >
               <v-icon left>mdi-delete-circle </v-icon>
               <!-- <span v-if="!selectedIssue.resolved">Delete</span> -->

--- a/src/store/transcription.js
+++ b/src/store/transcription.js
@@ -103,7 +103,7 @@ const actions = {
 
         store.dispatch('saveTranscription')
       },
-      2000,
+      5000,
     )
   },
 

--- a/test/unit/transcribe/spec/region-form.spec.js
+++ b/test/unit/transcribe/spec/region-form.spec.js
@@ -83,7 +83,7 @@ describe('components/RegionForm', function () {
 
       state.selectedRegion.issues = [{ some: 'issue' }]
 
-      await new Promise((resolve) => setTimeout(resolve, 10))
+      await new Promise((resolve) => setTimeout(resolve, 20))
       assert.equal(invalidateStub.callCount, 1)
     })
 
@@ -98,6 +98,24 @@ describe('components/RegionForm', function () {
 
       await new Promise((resolve) => setTimeout(resolve, 10))
       assert.equal(invalidateStub.callCount, 0)
+    })
+  })
+
+  describe('watch -> selectedRegion()', function () {
+    it('should invalidate issues AFTER region updates', async function () {
+      const wrapper = shallowMount(RegionForm, { store, localVue })
+      const rendered = wrapper.vm
+
+      const invalidateStub = this.sandbox.stub(rendered, 'doTriggerIssueInvalidation')
+      const setContentsStub = this.sandbox.stub(rendered, 'doSetEditorsContents')
+
+      state.selectedRegion = { issues: [{ some: 'issue' }] }
+
+      await new Promise((resolve) => setTimeout(resolve, 25))
+      assert.equal(invalidateStub.callCount, 1)
+      assert.equal(setContentsStub.callCount, 1)
+
+      sinon.assert.callOrder(setContentsStub, invalidateStub)
     })
   })
 })


### PR DESCRIPTION
Fixes a race condition where when you click on one region then another, the second region text gets updated with the first. The issue was that the issue invalidation was happening before the new region was updated, so the contents were getting out of whack. This adds tests to make sure that won't creep up again.