### PR TITLE
support for writing TH in Y Dialect

### DIFF
--- a/src/services/lexicon.js
+++ b/src/services/lexicon.js
@@ -124,7 +124,12 @@ class Lex {
   }
 
   replaceMacrons(word) {
-    word = word.replace(/ā/g, 'â').replace(/ē/g, 'ê').replace(/ī/g, 'î').replace(/ō/g, 'ô')
+    word = word
+      .replace(/ā/g, 'â')
+      .replace(/ē/g, 'ê')
+      .replace(/ī/g, 'î')
+      .replace(/ō/g, 'ô')
+      .replace(/ý/g, 'y')
     return word
   }
 


### PR DESCRIPTION
By adding this: .replace(/ý/g, 'y') I should be able to write TH material in Y dialect so that I can use all the spelling features. Later, we can programatically find all the TH dialect words as they'll be marked with ý and change them to match the TH dictionary (if it ever comes out).