### PR TITLE
Updates transcription on region save

### DIFF
--- a/src/__mocks__/testUtils.ts
+++ b/src/__mocks__/testUtils.ts
@@ -42,6 +42,7 @@ export function createMockStore(options: MockStoreOptions = {}) {
     source: 'test-source',
     type: 'test-type',
     author: 'test-author',
+    authorFriendly: 'Test Author',
     userLastUpdated: 'test-user',
     dateLastUpdated: '2023-01-01T00:00:00.000Z',
     createdAt: '2023-01-01T00:00:00.000Z',
@@ -102,6 +103,7 @@ export function createMockStore(options: MockStoreOptions = {}) {
     issueById: jest.fn(() => null),
     issuesByRegion: jest.fn(() => []),
     getState: jest.fn(),
+    calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 0, coverage: 0 })),
   };
 }
 

--- a/src/components/list/TranscriptionsTable.tsx
+++ b/src/components/list/TranscriptionsTable.tsx
@@ -265,7 +265,7 @@ export const TranscriptionsTable = () => {
                   
                   {/* Length */}
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 hidden lg:table-cell">
-                    {transcription.length}
+                    {transcription.lengthFriendly}
                   </td>
                   
                   {/* Coverage */}

--- a/src/components/player/WaveformPlayer.test.tsx
+++ b/src/components/player/WaveformPlayer.test.tsx
@@ -147,6 +147,7 @@ describe('WaveformPlayer', () => {
         regionById: jest.fn(() => null),
         issueById: jest.fn(() => null),
         issuesByRegion: jest.fn(() => []),
+        calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 0, coverage: 0 })),
       };
       return selector(state);
     });
@@ -540,6 +541,7 @@ describe('WaveformPlayer', () => {
         regionById: jest.fn(() => null),
         issueById: jest.fn(() => null),
         issuesByRegion: jest.fn(() => []),
+        calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 0, coverage: 0 })),
       };
       
       mockUseEditorStore.mockImplementation((selector) => selector(mockStateWithNoEdit));
@@ -623,6 +625,7 @@ describe('WaveformPlayer', () => {
           regionById: jest.fn(() => null),
           issueById: jest.fn(() => null),
           issuesByRegion: jest.fn(() => []),
+          calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 0, coverage: 0 })),
         };
         return selector(state);
       });

--- a/src/hooks/useDeleteRegion.ts
+++ b/src/hooks/useDeleteRegion.ts
@@ -4,8 +4,6 @@ import { services } from '../services';
 import { useEditorStore } from '../stores/useEditorStore';
 
 export const useDeleteRegion = () => {
-  const store = useEditorStore.getState();
-  
   const deleteRegion = useCallback(async (regionId: string) => {
     // Get user confirmation
     const confirmed = window.confirm(
@@ -17,7 +15,7 @@ export const useDeleteRegion = () => {
     }
 
     try {
-      const transcription = store.transcription;
+      const transcription = useEditorStore.getState().transcription;
       if (!transcription) {
         throw new Error('No transcription loaded');
       }
@@ -32,7 +30,7 @@ export const useDeleteRegion = () => {
         transcriptionId: transcription.id,
         user,
         services,
-        store,
+        store: useEditorStore.getState(),
       });
 
       await useCase.execute();
@@ -42,7 +40,7 @@ export const useDeleteRegion = () => {
       // Show user-friendly error message
       alert('Failed to delete region. Please try again.');
     }
-  }, [store]);
+  }, []);
 
   return { deleteRegion };
 }; 

--- a/src/hooks/useTextEditors.ts
+++ b/src/hooks/useTextEditors.ts
@@ -53,7 +53,7 @@ export const useTextEditors = (regionId: string, activeTab: 'main' | 'translatio
           regionId,
           text,
           field: 'regionText',
-          store: useEditorStore,
+          store: useEditorStore.getState(),
           services
         }).execute();
 
@@ -67,7 +67,7 @@ export const useTextEditors = (regionId: string, activeTab: 'main' | 'translatio
           regionId,
           text,
           services,
-          store: useEditorStore
+          store: useEditorStore.getState()
         }).execute();
       });
     }
@@ -110,7 +110,7 @@ export const useTextEditors = (regionId: string, activeTab: 'main' | 'translatio
           regionId,
           text,
           field: 'translation',
-          store: useEditorStore,
+          store: useEditorStore.getState(),
           services
         }).execute();
       });

--- a/src/hooks/useUpdateTranscription.test.ts
+++ b/src/hooks/useUpdateTranscription.test.ts
@@ -120,7 +120,6 @@ describe('useUpdateTranscription', () => {
       expect(MockedUpdateTranscriptionUseCase).toHaveBeenCalledWith({
         transcriptionId: 'test-transcription-id',
         updates: { title: 'New Title' },
-        username: 'testuser',
         services: expect.any(Object),
         store: mockStore,
       });
@@ -138,7 +137,6 @@ describe('useUpdateTranscription', () => {
       expect(MockedUpdateTranscriptionUseCase).toHaveBeenCalledWith({
         transcriptionId: 'test-transcription-id',
         updates: { title: 'New Title', comments: 'New comments' },
-        username: 'testuser',
         services: expect.any(Object),
         store: mockStore,
       });
@@ -154,7 +152,6 @@ describe('useUpdateTranscription', () => {
       expect(MockedUpdateTranscriptionUseCase).toHaveBeenCalledWith({
         transcriptionId: 'test-transcription-id',
         updates: { comments: 'Just comments' },
-        username: 'testuser',
         services: expect.any(Object),
         store: mockStore,
       });
@@ -170,7 +167,6 @@ describe('useUpdateTranscription', () => {
       expect(MockedUpdateTranscriptionUseCase).toHaveBeenCalledWith({
         transcriptionId: 'test-transcription-id',
         updates: {},
-        username: 'testuser',
         services: expect.any(Object),
         store: mockStore,
       });

--- a/src/hooks/useUpdateTranscription.ts
+++ b/src/hooks/useUpdateTranscription.ts
@@ -18,14 +18,12 @@ export const useUpdateTranscription = (transcriptionId: string) => {
         throw new Error('User must be authenticated to update transcription');
       }
 
-      const store = useEditorStore.getState();
-      
+      const state = useEditorStore.getState();
       new UpdateTranscriptionUseCase({
         transcriptionId,
         updates,
-        username: user.username,
         services,
-        store,
+        state,
       }).execute();
     }
   };

--- a/src/hooks/useUpdateTranscription.ts
+++ b/src/hooks/useUpdateTranscription.ts
@@ -18,12 +18,12 @@ export const useUpdateTranscription = (transcriptionId: string) => {
         throw new Error('User must be authenticated to update transcription');
       }
 
-      const state = useEditorStore.getState();
+      const store = useEditorStore.getState();
       new UpdateTranscriptionUseCase({
         transcriptionId,
         updates,
         services,
-        state,
+        store,
       }).execute();
     }
   };

--- a/src/hooks/useWavesurferEvents.ts
+++ b/src/hooks/useWavesurferEvents.ts
@@ -8,6 +8,7 @@ import { services } from '../services';
 
 import { CreateRegion } from '../use-cases/create-region';
 import { UpdateRegionBounds } from '../use-cases/update-region-bounds';
+import { UpdateTranscriptionUseCase } from '../use-cases/update-transcription';
 
 // Wavesurfer event interfaces
 interface RegionCreatedEvent {
@@ -55,12 +56,11 @@ export const useWavesurferEvents = (transcriptionId: string, source?: string): v
     const handleRegionCreated = (data: unknown) => {
       const event = data as RegionCreatedEvent;
       console.log('Region Created', event);
-      const store = useEditorStore.getState();
       const usecase = new CreateRegion({
         transcriptionId,
         newRegion: { id: event.id, start: event.start, end: event.end },
         services,
-        store,
+        store: useEditorStore.getState(),
       });
       usecase.execute();
     };
@@ -68,7 +68,6 @@ export const useWavesurferEvents = (transcriptionId: string, source?: string): v
     const handleRegionUpdateEnd = (data: unknown) => {
       const event = data as RegionUpdateEndEvent;
       console.log('Region Updated', event);
-      const store = useEditorStore.getState();
       const user = services.authService.currentUser();
       if (!user) {
         console.warn('Cannot update region bounds: user not authenticated');
@@ -81,7 +80,7 @@ export const useWavesurferEvents = (transcriptionId: string, source?: string): v
         newEnd: event.end,
         user,
         services,
-        store,
+        store: useEditorStore.getState(),
       });
       usecase.execute();
     };
@@ -133,8 +132,24 @@ export const useWavesurferEvents = (transcriptionId: string, source?: string): v
 
     const handleReadyWithDuration = (data: unknown) => {
       const event = data as ReadyEvent;
+      console.log('wavesurfer ready', event)
       usePlayerStore.getState().setLoadedAndReady(true);
       usePlayerStore.getState().setDuration(event.duration);
+      
+      // Update transcription length with the actual duration from wavesurfer
+      const state = useEditorStore.getState();
+      const transcription = state.transcription
+      if (transcription && transcription.length === 0 && event.duration > 0) {
+        const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
+          transcriptionId: transcription.id,
+          updates: { length: event.duration },
+          services,
+          state,
+        });
+        updateTranscriptionUseCase.execute().catch(error => {
+          console.warn('Failed to update transcription length:', error);
+        });
+      }
     };
 
     wavesurferService.on('region-created', handleRegionCreated);

--- a/src/hooks/useWavesurferEvents.ts
+++ b/src/hooks/useWavesurferEvents.ts
@@ -137,14 +137,15 @@ export const useWavesurferEvents = (transcriptionId: string, source?: string): v
       usePlayerStore.getState().setDuration(event.duration);
       
       // Update transcription length with the actual duration from wavesurfer
-      const state = useEditorStore.getState();
-      const transcription = state.transcription
+      const store = useEditorStore.getState();
+      const transcription = store.transcription
+      console.log(transcription, event)
       if (transcription && transcription.length === 0 && event.duration > 0) {
         const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
           transcriptionId: transcription.id,
           updates: { length: event.duration },
           services,
-          state,
+          store,
         });
         updateTranscriptionUseCase.execute().catch(error => {
           console.warn('Failed to update transcription length:', error);

--- a/src/services/adt.test.ts
+++ b/src/services/adt.test.ts
@@ -129,20 +129,20 @@ describe('ADT Models', () => {
         testCases.forEach(({ input, expected }) => {
           const data = { ...mockTranscriptionData, length: input };
           const model = new TranscriptionModel(data);
-          expect(model.length).toBe(expected);
+          expect(model.lengthFriendly).toBe(expected);
         });
       });
 
       it('should handle zero length', () => {
         const data = { ...mockTranscriptionData, length: 0 };
         const model = new TranscriptionModel(data);
-        expect(model.length).toBe('00:00');
+        expect(model.lengthFriendly).toBe('00:00');
       });
 
       it('should handle decimal seconds properly', () => {
         const data = { ...mockTranscriptionData, length: 61.789 };
         const model = new TranscriptionModel(data);
-        expect(model.length).toBe('01:01');
+        expect(model.lengthFriendly).toBe('01:01');
       });
 
       it('should handle edge case length values', () => {
@@ -150,28 +150,27 @@ describe('ADT Models', () => {
         const model = new TranscriptionModel(dataWithLargeLength);
         
         // Should return a formatted string
-        expect(typeof model.length).toBe('string');
-        expect(model.length).toMatch(/^\d+:\d{2}$/);
+        expect(typeof model.lengthFriendly).toBe('string');
+        expect(model.lengthFriendly).toMatch(/^\d+:\d{2}$/);
       });
     });
 
-    describe('length setter', () => {
-      it('should set internal length value', () => {
-        const model = new TranscriptionModel(mockTranscriptionData);
+    describe('length initialization', () => {
+      it('should initialize internal length value from constructor', () => {
+        const data = { ...mockTranscriptionData, length: 180.5 };
+        const model = new TranscriptionModel(data);
         
-        model.length = 180.5;
-        expect((model as any)._length).toBe(180.5);
-        expect(model.length).toBe('03:00'); // Getter should reflect new value
+        expect((model as any).length).toBe(180.5);
+        expect(model.lengthFriendly).toBe('03:00'); // Getter should reflect constructor value
       });
 
-      it('should handle different numeric values', () => {
-        const model = new TranscriptionModel(mockTranscriptionData);
-        
+      it('should handle different numeric values in constructor', () => {
         const testValues = [0, 30.5, 120, 3600.789];
         
         testValues.forEach(value => {
-          model.length = value;
-          expect((model as any)._length).toBe(value);
+          const data = { ...mockTranscriptionData, length: value };
+          const model = new TranscriptionModel(data);
+          expect((model as any).length).toBe(value);
         });
       });
     });

--- a/src/services/adt.ts
+++ b/src/services/adt.ts
@@ -116,7 +116,7 @@ export class TranscriptionModel {
   public editors?: string[] | null;
   public viewers?: string[] | null;
   public accessLevel?: 'owner' | 'editor' | 'viewer' | null;
-  private _length: number;
+  private length: number;
 
   constructor(data: TranscriptionData) {
     if (!data) {
@@ -143,7 +143,7 @@ export class TranscriptionModel {
     this.editors = data.editors;
     this.viewers = data.viewers;
     this.isVideo = data.type?.includes('video') || false;
-    this._length = data.length || 0;
+    this.length = data.length || 0;
   }
 
   /**
@@ -156,18 +156,14 @@ export class TranscriptionModel {
   /**
    * Provide the length of the transcription audio in MM:SS
    */
-  get length(): string {
+  get lengthFriendly(): string {
     try {
-      const length = String(floatToMSM(this._length)).split('.')[0];
+      const length = String(floatToMSM(this.length)).split('.')[0];
       return length;
     } catch (error) {
       console.warn('Error parsing length', error);
       return '0';
     }
-  }
-
-  set length(value: number) {
-    this._length = value;
   }
 
   /**

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -11,7 +11,6 @@ import { createRegion as createRegionMutation, updateRegion as updateRegionMutat
 import { getRegion as getRegionQuery } from '../graphql/queries.js';
 
 import { RegionModel } from './adt';
-import { showToast } from './toastService';
 import { type RegionData } from './adt';
 import { 
   type GraphQLClient,
@@ -106,8 +105,7 @@ export const createRegion = async (
     const created = data?.createRegion;
     return new RegionModel(created);
   } catch (error) {
-    // console.error('❌ Failed to create region via API:', error);
-    showToast('Failed to create region', 'error');
+    console.error('❌ Failed to create region via API:', error);
     throw error;
   }
 };
@@ -149,11 +147,9 @@ export const updateRegion = async (regionId: string, updates: Partial<RegionData
 
     const analysisInfo = updates.regionAnalysis ? ` + analysis` : '';
     console.log(`✅ Saved region ${regionId}${analysisInfo}`);
-    showToast(`Saved region ${regionId.slice(0, 8)}...${analysisInfo}`, 'success');
     
   } catch (error) {
     console.error(`❌ Failed to save region ${regionId}:`, error);
-    showToast(`Failed to save region ${regionId.slice(0, 8)}...`, 'error');
     throw error;
   }
 };
@@ -187,12 +183,10 @@ export const deleteRegion = async (regionId: string) => {
       authMode: 'iam',
     });
     
-    // console.log(`✅ Deleted region ${regionId}`);
-    showToast(`Deleted region ${regionId.slice(0, 8)}...`, 'success');
+    console.log(`✅ Deleted region ${regionId}`);
     
   } catch (error) {
-    // console.error(`❌ Failed to delete region ${regionId}:`, error);
-    showToast(`Failed to delete region ${regionId.slice(0, 8)}...`, 'error');
+    console.error(`❌ Failed to delete region ${regionId}:`, error);
     throw error;
   }
 };

--- a/src/stores/useEditorStore.ts
+++ b/src/stores/useEditorStore.ts
@@ -50,9 +50,13 @@ interface EditorState {
   setSelectedRegion: (regionId: string | null) => void;
   setPlaybackWithinRegion: (regionId: string | null) => void;
   addNewRegion: (region: RegionData) => void;
+  deleteRegion: (regionId: string) => void;
   setRegionText: (regionId: string, text: string) => void;
   setRegionTranslation: (regionId: string, translation: string) => void;
   updateRegionBounds: (regionId: string, start: number, end: number) => void;
+
+  // Transcription metadata helpers
+  calculateTranscriptionMetadata: () => { regionCount: number; coverage: number };
 
   // Spell checking actions
   addKnownWords: (words: string[]) => void;
@@ -216,6 +220,31 @@ export const useEditorStore = create<EditorState>()(
         });
       },
 
+      deleteRegion: (regionId: string) => {
+        const { regions, regionMap, selectedRegionId } = get();
+        
+        // Remove from regionMap
+        const newRegionMap = { ...regionMap };
+        delete newRegionMap[regionId];
+        
+        // Remove from regions array
+        const newRegions = regions.filter(r => r.id !== regionId);
+        
+        // Prepare the update object
+        const updateObj: Partial<EditorState> = {
+          regions: newRegions,
+          regionMap: newRegionMap,
+        };
+        
+        // If this was the selected region, clear the selection
+        if (selectedRegionId === regionId) {
+          updateObj.selectedRegionId = null;
+          updateObj.selectedRegion = null;
+        }
+        
+        set(updateObj);
+      },
+
       setRegionText: (regionId, text) => {
         const { regionMap, regions, selectedRegionId } = get();
         const existingRegion = regionMap[regionId];
@@ -349,6 +378,23 @@ export const useEditorStore = create<EditorState>()(
         }
         
         set(updateObj);
+      },
+
+      // Transcription metadata helpers
+      calculateTranscriptionMetadata: () => {
+        const { regions, transcription } = get();
+        
+        const regionCount = regions.length;
+        
+        // Calculate coverage: last region end / total transcription length
+        let coverage = 0;
+        if (regions.length > 0 && transcription?.length) {
+          // Find the latest end time among all regions
+          const lastRegionEnd = Math.max(...regions.map(r => r.end));
+          coverage = Math.min(lastRegionEnd / transcription.length, 1.0); // Cap at 1.0
+        }
+        
+        return { regionCount, coverage };
       },
     }),
     { name: 'EditorStore' }

--- a/src/use-cases/analyze-region-text.test.ts
+++ b/src/use-cases/analyze-region-text.test.ts
@@ -32,6 +32,9 @@ const mockStateActions = {
 };
 
 const mockStore = {
+  knownWords: new Set<string>(['existing', 'word', 'hello', 'êkwa', 'itwêw']),
+  setRegionAnalysis: jest.fn(),
+  addKnownWords: jest.fn(),
   getState: jest.fn(),
   setState: jest.fn(),
   subscribe: jest.fn()
@@ -91,10 +94,10 @@ describe('AnalyzeRegionTextUseCase', () => {
       expect(mockSpellCheckerService.check).toHaveBeenCalledWith(['world']); // only unknown words
       
       // Should not call addKnownWords since no new words were discovered
-      expect(mockStateActions.addKnownWords).not.toHaveBeenCalled();
+      expect(mockStore.addKnownWords).not.toHaveBeenCalled();
       
       // Should set region analysis (with all known words including cached ones)
-      expect(mockStateActions.setRegionAnalysis).toHaveBeenCalledWith('region-1', ['hello', 'êkwa']);
+      expect(mockStore.setRegionAnalysis).toHaveBeenCalledWith('region-1', ['hello', 'êkwa']);
       
       jest.useRealTimers();
     });
@@ -167,8 +170,8 @@ describe('AnalyzeRegionTextUseCase', () => {
       await promise;
 
       expect(mockSpellCheckerService.check).toHaveBeenCalledWith(['tâpwê']); // only unknown word
-      expect(mockStateActions.addKnownWords).toHaveBeenCalledWith(['tâpwê']);
-      expect(mockStateActions.setRegionAnalysis).toHaveBeenCalledWith('region-1', ['itwêw', 'êkwa', 'tâpwê']);
+      expect(mockStore.addKnownWords).toHaveBeenCalledWith(['tâpwê']);
+      expect(mockStore.setRegionAnalysis).toHaveBeenCalledWith('region-1', ['itwêw', 'êkwa', 'tâpwê']);
       
       jest.useRealTimers();
     });
@@ -258,8 +261,8 @@ describe('AnalyzeRegionTextUseCase', () => {
 
       // Should analyze both regions
       expect(mockSpellCheckerService.tokenize).toHaveBeenCalledTimes(2);
-      expect(mockStateActions.setRegionAnalysis).toHaveBeenCalledWith('region-1', expect.any(Array));
-      expect(mockStateActions.setRegionAnalysis).toHaveBeenCalledWith('region-2', expect.any(Array));
+      expect(mockStore.setRegionAnalysis).toHaveBeenCalledWith('region-1', expect.any(Array));
+      expect(mockStore.setRegionAnalysis).toHaveBeenCalledWith('region-2', expect.any(Array));
       
       jest.useRealTimers();
     });

--- a/src/use-cases/analyze-region-text.ts
+++ b/src/use-cases/analyze-region-text.ts
@@ -60,12 +60,12 @@ export class AnalyzeRegionTextUseCase {
     const words = spellCheckerService.tokenize(text);
     if (words.length === 0) {
       // Set empty analysis for empty text
-      store.getState().setRegionAnalysis(regionId, []);
+      store.setRegionAnalysis(regionId, []);
       return;
     }
 
     // Get global known words from store
-    const globalKnownWords = store.getState().knownWords as Set<string>;
+    const globalKnownWords = store.knownWords as Set<string>;
     
     // Separate words into already known and unknown
     const alreadyKnownWords: string[] = [];
@@ -92,7 +92,7 @@ export class AnalyzeRegionTextUseCase {
         if (result.known.length > 0) {
           allKnownWords.push(...result.known);
           // Update global store with newly discovered known words
-          store.getState().addKnownWords(result.known);
+          store.addKnownWords(result.known);
         }
       } catch (error) {
         console.error('Error checking unknown words:', error);
@@ -100,7 +100,7 @@ export class AnalyzeRegionTextUseCase {
     }
 
     // Update region analysis in store (this will be picked up by the coordinated save)
-    store.getState().setRegionAnalysis(regionId, allKnownWords);
+    store.setRegionAnalysis(regionId, allKnownWords);
 
     // Apply formatting to the main editor
     const mainEditorKey: EditorKey = `${regionId}:main`;

--- a/src/use-cases/create-region.test.ts
+++ b/src/use-cases/create-region.test.ts
@@ -16,10 +16,21 @@ describe('CreateRegion', () => {
     regionService: {
       createRegion: mockCreateRegion,
     },
+    transcriptionService: {
+      updateTranscription: jest.fn(),
+    },
   };
 
   const mockStore = {
     addNewRegion: mockAddNewRegion,
+    transcription: {
+      id: 'test-transcription-id',
+      title: 'Test Transcription',
+      length: 120,
+    },
+    regions: [],
+    calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 0, coverage: 0 })),
+    setTranscription: jest.fn(),
   };
 
   const validConfig = {
@@ -155,7 +166,7 @@ describe('CreateRegion', () => {
       
       await expect(useCase.execute()).resolves.not.toThrow();
       
-      expect(mockCurrentUser).toHaveBeenCalledTimes(1);
+      expect(mockCurrentUser).toHaveBeenCalledTimes(2); // Called by CreateRegion and UpdateTranscriptionUseCase
       expect(mockAddNewRegion).toHaveBeenCalledTimes(1);
       expect(mockCreateRegion).toHaveBeenCalledTimes(1);
     });

--- a/src/use-cases/create-region.ts
+++ b/src/use-cases/create-region.ts
@@ -1,4 +1,6 @@
 import { services } from '../services';
+import { showToast } from '../services/toastService';
+import { UpdateTranscriptionUseCase } from './update-transcription';
 
 interface CreateRegionConfig {
   transcriptionId: string;
@@ -40,10 +42,27 @@ export class CreateRegion {
     const transcriptionId = this.config.transcriptionId
     const userLastUpdated = this.user?.username || 'unknown'
 
-    // save to store
+    // save to store (optimistic update)
     store.addNewRegion(newRegion)
 
-    // async save to DB
-    regionService.createRegion(transcriptionId, newRegion, userLastUpdated)
+    try {
+      // async save to DB
+      await regionService.createRegion(transcriptionId, newRegion, userLastUpdated)
+      
+      // Update the transcription with metadata
+      const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
+        transcriptionId: this.config.transcriptionId,
+        services: this.config.services,
+        state: store,
+      });
+      
+      await updateTranscriptionUseCase.execute();
+      
+    } catch (error) {
+      console.error('Failed to create region:', error);
+      
+      // TODO: Consider reverting optimistic update on error
+      throw error;
+    }
   }
 } 

--- a/src/use-cases/create-region.ts
+++ b/src/use-cases/create-region.ts
@@ -53,7 +53,7 @@ export class CreateRegion {
       const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
         transcriptionId: this.config.transcriptionId,
         services: this.config.services,
-        state: store,
+        store: store,
       });
       
       await updateTranscriptionUseCase.execute();

--- a/src/use-cases/create-region.ts
+++ b/src/use-cases/create-region.ts
@@ -1,5 +1,4 @@
 import { services } from '../services';
-import { showToast } from '../services/toastService';
 import { UpdateTranscriptionUseCase } from './update-transcription';
 
 interface CreateRegionConfig {

--- a/src/use-cases/delete-region.test.ts
+++ b/src/use-cases/delete-region.test.ts
@@ -19,6 +19,10 @@ describe('DeleteRegion', () => {
   const mockStore = {
     regionById: jest.fn(),
     deleteRegion: jest.fn(),
+    getState: jest.fn(() => ({
+      regionById: jest.fn(() => ({ transcriptionId: 'transcription123' })),
+    })),
+    calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 1, coverage: 0.5 })),
   };
 
   const mockUser = {

--- a/src/use-cases/delete-region.test.ts
+++ b/src/use-cases/delete-region.test.ts
@@ -14,15 +14,25 @@ describe('DeleteRegion', () => {
     authService: {
       currentUser: jest.fn(),
     },
+    transcriptionService: {
+      updateTranscription: jest.fn(),
+    },
   };
 
   const mockStore = {
     regionById: jest.fn(),
     deleteRegion: jest.fn(),
+    transcription: {
+      id: 'transcription123',
+      title: 'Test Transcription',
+      length: 120,
+    },
+    regions: [],
+    calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 1, coverage: 0.5 })),
+    setTranscription: jest.fn(),
     getState: jest.fn(() => ({
       regionById: jest.fn(() => ({ transcriptionId: 'transcription123' })),
     })),
-    calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 1, coverage: 0.5 })),
   };
 
   const mockUser = {
@@ -35,6 +45,7 @@ describe('DeleteRegion', () => {
     start: 10,
     end: 20,
     regionText: 'Test region',
+    transcriptionId: 'transcription123',
   };
 
   const validConfig = {

--- a/src/use-cases/delete-region.ts
+++ b/src/use-cases/delete-region.ts
@@ -1,4 +1,6 @@
 import { services } from '../services';
+import { showToast } from '../services/toastService';
+import { UpdateTranscriptionUseCase } from './update-transcription';
 import type { User, WavesurferRegion } from '../types/shared';
 
 interface DeleteRegionConfig {
@@ -60,6 +62,10 @@ export class DeleteRegion {
         }
       }
 
+      // Get the region's transcriptionId before we delete it
+      const region = this.config.store.regionById(this.config.regionId);
+      const transcriptionId = region.transcriptionId;
+
       // Remove from store (optimistic update) - this is now synchronous
       this.config.store.deleteRegion(this.config.regionId);
       console.log(`🗑️ Removed region ${this.config.regionId} from store`);
@@ -67,6 +73,15 @@ export class DeleteRegion {
       // Remove from backend
       await this.config.services.regionService.deleteRegion(this.config.regionId);
       console.log(`🗑️ Successfully deleted region ${this.config.regionId} from backend`);
+      
+      // Update the transcription with metadata
+      const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
+        transcriptionId,
+        services: this.config.services,
+        state: this.config.store,
+      });
+      
+      await updateTranscriptionUseCase.execute();
 
     } catch (error) {
       console.error('Failed to delete region:', error);

--- a/src/use-cases/delete-region.ts
+++ b/src/use-cases/delete-region.ts
@@ -1,5 +1,4 @@
 import { services } from '../services';
-import { showToast } from '../services/toastService';
 import { UpdateTranscriptionUseCase } from './update-transcription';
 import type { User, WavesurferRegion } from '../types/shared';
 

--- a/src/use-cases/delete-region.ts
+++ b/src/use-cases/delete-region.ts
@@ -78,7 +78,7 @@ export class DeleteRegion {
       const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
         transcriptionId,
         services: this.config.services,
-        state: this.config.store,
+        store: this.config.store,
       });
       
       await updateTranscriptionUseCase.execute();

--- a/src/use-cases/update-region-bounds.ts
+++ b/src/use-cases/update-region-bounds.ts
@@ -69,7 +69,7 @@ export class UpdateRegionBounds {
       const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
         transcriptionId: existingRegion.transcriptionId,
         services,
-        state: store,
+        store: store,
       });
       
       await updateTranscriptionUseCase.execute();

--- a/src/use-cases/update-region-bounds.ts
+++ b/src/use-cases/update-region-bounds.ts
@@ -1,5 +1,4 @@
 import { services } from '../services';
-import { showToast } from '../services/toastService';
 import { UpdateTranscriptionUseCase } from './update-transcription';
 import type { User } from '../types/shared';
 

--- a/src/use-cases/update-region-bounds.ts
+++ b/src/use-cases/update-region-bounds.ts
@@ -1,4 +1,6 @@
 import { services } from '../services';
+import { showToast } from '../services/toastService';
+import { UpdateTranscriptionUseCase } from './update-transcription';
 import type { User } from '../types/shared';
 
 interface UpdateRegionBoundsConfig {
@@ -62,6 +64,15 @@ export class UpdateRegionBounds {
         { start: newStart, end: newEnd },
         username
       );
+
+      // Update the transcription with metadata  
+      const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
+        transcriptionId: existingRegion.transcriptionId,
+        services,
+        state: store,
+      });
+      
+      await updateTranscriptionUseCase.execute();
 
     } catch (error) {
       console.error(`❌ Failed to save region ${regionId} bounds:`, error);

--- a/src/use-cases/update-region-text.test.ts
+++ b/src/use-cases/update-region-text.test.ts
@@ -291,7 +291,6 @@ describe('UpdateRegionTextUseCase', () => {
       
       expect(() => useCase.execute()).not.toThrow();
       
-      expect(mockStore.getState).toHaveBeenCalledTimes(1);
       expect(mockSetRegionText).toHaveBeenCalledWith('test-region-id', 'Test text content');
     });
 
@@ -308,19 +307,17 @@ describe('UpdateRegionTextUseCase', () => {
       
       expect(() => useCase.execute()).not.toThrow();
       
-      expect(mockStore.getState).toHaveBeenCalledTimes(1);
       expect(mockSetRegionTranslation).toHaveBeenCalledWith('translation-region-id', 'Translated content');
     });
 
     it('should work with real store structure', () => {
       // Test with a more realistic store mock structure
       const realisticStore = {
-        getState: () => ({
-          setRegionText: mockSetRegionText,
-          setRegionTranslation: mockSetRegionTranslation,
-          regions: [],
-          selectedRegionId: null
-        })
+        setRegionText: mockSetRegionText,
+        setRegionTranslation: mockSetRegionTranslation,
+        regionById: jest.fn(() => ({ transcriptionId: 'test-transcription-id', regionAnalysis: ['word1', 'word2'] })),
+        regions: [],
+        selectedRegionId: null
       } as any; // Type assertion for testing
       
       const realisticConfig = {

--- a/src/use-cases/update-region-text.ts
+++ b/src/use-cases/update-region-text.ts
@@ -1,4 +1,6 @@
 import { services } from '../services';
+import { showToast } from '../services/toastService';
+import { UpdateTranscriptionUseCase } from './update-transcription';
 import Timeout from 'smart-timeout';
 
 interface UpdateRegionTextConfig {
@@ -32,11 +34,10 @@ export class UpdateRegionTextUseCase {
     const { regionId, text, field, store, services } = this.config;
 
     // Update local store immediately for responsive UI
-    const storeState = store.getState();
     if (field === 'regionText') {
-      storeState.setRegionText(regionId, text);
+      store.setRegionText(regionId, text);
     } else {
-      storeState.setRegionTranslation(regionId, text);
+      store.setRegionTranslation(regionId, text);
     }
 
     // Check if user is authenticated
@@ -56,8 +57,7 @@ export class UpdateRegionTextUseCase {
     const timeoutKey = `region-text-save-${regionId}`;
     Timeout.set(timeoutKey, async () => {
       try {
-        // Get fresh store state at save time
-        const currentStoreState = store.getState();
+        // Get fresh state at save time
         
         // Prepare update data
         const updateData: {
@@ -71,7 +71,7 @@ export class UpdateRegionTextUseCase {
         // If updating main text, include current analysis from store at save time
         if (field === 'regionText') {
           try {
-            const region = currentStoreState.regionById(regionId);
+            const region = store.regionById(regionId);
             if (region?.regionAnalysis) {
               updateData.regionAnalysis = region.regionAnalysis;
             }
@@ -90,6 +90,16 @@ export class UpdateRegionTextUseCase {
 
         // Remove from pending saves
         pendingSaves.delete(regionId);
+
+        // Update the transcription with metadata
+        const region = store.regionById(regionId);
+        const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
+          transcriptionId: region.transcriptionId,
+          services,
+          state: store,
+        });
+        
+        await updateTranscriptionUseCase.execute();
         
       } catch (error) {
         console.error('Failed to save region text:', error);

--- a/src/use-cases/update-region-text.ts
+++ b/src/use-cases/update-region-text.ts
@@ -1,5 +1,4 @@
 import { services } from '../services';
-import { showToast } from '../services/toastService';
 import { UpdateTranscriptionUseCase } from './update-transcription';
 import Timeout from 'smart-timeout';
 

--- a/src/use-cases/update-region-text.ts
+++ b/src/use-cases/update-region-text.ts
@@ -96,7 +96,7 @@ export class UpdateRegionTextUseCase {
         const updateTranscriptionUseCase = new UpdateTranscriptionUseCase({
           transcriptionId: region.transcriptionId,
           services,
-          state: store,
+          store: store,
         });
         
         await updateTranscriptionUseCase.execute();

--- a/src/use-cases/update-transcription.test.ts
+++ b/src/use-cases/update-transcription.test.ts
@@ -10,6 +10,9 @@ jest.mock('../services', () => ({
     transcriptionService: {
       updateTranscription: jest.fn(),
     },
+    authService: {
+      currentUser: jest.fn(() => ({ username: 'test-user@example.com', userId: 'user123' })),
+    },
   },
 }));
 
@@ -27,6 +30,17 @@ const MockedTranscriptionModel = TranscriptionModel as jest.MockedClass<typeof T
 
 describe('UpdateTranscriptionUseCase', () => {
   const mockStore = {
+    transcription: {
+      id: 'test-transcription-id',
+      title: 'Original Title',
+      length: 120,
+      userLastUpdated: 'original-user',
+      dateLastUpdated: '2023-01-01T00:00:00.000Z',
+    },
+    regions: [
+      { id: 'region1', start: 0, end: 30 },
+      { id: 'region2', start: 30, end: 60 },
+    ],
     setTranscription: jest.fn(),
     calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 2, coverage: 0.75 })),
   };
@@ -50,19 +64,7 @@ describe('UpdateTranscriptionUseCase', () => {
       expect(() => useCase.validate()).toThrow('transcriptionId is required');
     });
 
-    it('should throw error when username is missing', () => {
-      const config = { ...baseConfig, username: '' };
-      const useCase = new UpdateTranscriptionUseCase(config);
-      
-      expect(() => useCase.validate()).toThrow('username is required');
-    });
 
-    it('should throw error when updates are empty', () => {
-      const config = { ...baseConfig, updates: {} };
-      const useCase = new UpdateTranscriptionUseCase(config);
-      
-      expect(() => useCase.validate()).toThrow('updates are required');
-    });
 
     it('should throw error when title is empty string', () => {
       const config = { ...baseConfig, updates: { title: '' } };
@@ -98,12 +100,19 @@ describe('UpdateTranscriptionUseCase', () => {
         'test-transcription-id',
         expect.objectContaining({
           title: 'New Title',
-          userLastUpdated: 'testuser',
+          userLastUpdated: 'test-user',
           dateLastUpdated: expect.any(String),
         })
       );
 
-      expect(mockStore.setTranscription).toHaveBeenCalledWith(rawTranscription);
+      // Verify that the combined data was passed to the store
+      expect(mockStore.setTranscription).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'New Title',
+          userLastUpdated: 'test-user',
+          coverage: 0.75,
+        })
+      );
       expect(mockShowToast).toHaveBeenCalledWith('Transcription saved', 'success');
     });
 
@@ -125,12 +134,20 @@ describe('UpdateTranscriptionUseCase', () => {
         expect.objectContaining({
           title: 'New Title',
           comments: 'New comments',
-          userLastUpdated: 'testuser',
+          userLastUpdated: 'test-user',
           dateLastUpdated: expect.any(String),
         })
       );
 
-      expect(mockStore.setTranscription).toHaveBeenCalledWith(rawTranscription);
+      // Verify that the combined data was passed to the store
+      expect(mockStore.setTranscription).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'New Title',
+          comments: 'New comments',
+          userLastUpdated: 'test-user',
+          coverage: 0.75,
+        })
+      );
       expect(mockShowToast).toHaveBeenCalledWith('Transcription saved', 'success');
     });
 
@@ -143,19 +160,27 @@ describe('UpdateTranscriptionUseCase', () => {
       await expect(useCase.execute()).rejects.toThrow('Network error');
 
       expect(mockShowToast).toHaveBeenCalledWith('Failed to save transcription', 'error');
-      expect(mockStore.setTranscription).not.toHaveBeenCalled();
+      // Note: setTranscription is called for optimistic update even if API fails
+      expect(mockStore.setTranscription).toHaveBeenCalled();
     });
 
-    it('should pass raw transcription data to store', async () => {
-      const rawTranscription = { id: 'test-id', title: 'Video Title', type: 'video/mp4' };
+    it('should pass combined transcription data to store', async () => {
+      const apiResponse = { id: 'test-id', title: 'Video Title', type: 'video/mp4' };
 
-      (mockServices.transcriptionService.updateTranscription as jest.Mock).mockResolvedValue(rawTranscription);
+      (mockServices.transcriptionService.updateTranscription as jest.Mock).mockResolvedValue(apiResponse);
 
       const useCase = new UpdateTranscriptionUseCase(baseConfig);
       await useCase.execute();
 
-      // Verify that the raw data was passed to the store
-      expect(mockStore.setTranscription).toHaveBeenCalledWith(rawTranscription);
+      // Verify that the combined data (current + updates + metadata) was passed to the store
+      expect(mockStore.setTranscription).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'test-transcription-id',
+          title: 'New Title',
+          userLastUpdated: 'test-user',
+          coverage: 0.75,
+        })
+      );
     });
   });
 }); 

--- a/src/use-cases/update-transcription.test.ts
+++ b/src/use-cases/update-transcription.test.ts
@@ -28,12 +28,12 @@ const MockedTranscriptionModel = TranscriptionModel as jest.MockedClass<typeof T
 describe('UpdateTranscriptionUseCase', () => {
   const mockStore = {
     setTranscription: jest.fn(),
+    calculateTranscriptionMetadata: jest.fn(() => ({ regionCount: 2, coverage: 0.75 })),
   };
 
   const baseConfig: UpdateTranscriptionConfig = {
     transcriptionId: 'test-transcription-id',
     updates: { title: 'New Title' },
-    username: 'testuser',
     services: mockServices,
     store: mockStore as any,
   };

--- a/src/use-cases/update-transcription.ts
+++ b/src/use-cases/update-transcription.ts
@@ -13,7 +13,7 @@ export interface UpdateTranscriptionConfig {
   };
   services: typeof services;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  state: any;
+  store: any;
 }
 
 export class UpdateTranscriptionUseCase {
@@ -28,8 +28,8 @@ export class UpdateTranscriptionUseCase {
       throw new Error('transcriptionId is required');
     }
 
-    if (!this.config.state) {
-      throw new Error('state is required');
+    if (!this.config.store) {
+      throw new Error('store is required');
     }
 
     // Check if title is provided and validate it
@@ -43,7 +43,7 @@ export class UpdateTranscriptionUseCase {
   async execute(): Promise<TranscriptionData> {
     this.validate();
 
-    const { transcriptionId, updates, state, services } = this.config;
+    const { transcriptionId, updates, store, services } = this.config;
 
     // Get current user from auth service
     const user = services.authService.currentUser();
@@ -52,12 +52,12 @@ export class UpdateTranscriptionUseCase {
     }
 
     // Calculate the complete updated transcription
-    const currentTranscription = state.transcription;
+    const currentTranscription = store.transcription;
     if (!currentTranscription) {
-      throw new Error('No transcription found in state');
+      throw new Error('No transcription found in store');
     }
 
-        const { coverage } = state.calculateTranscriptionMetadata();
+        const { coverage } = store.calculateTranscriptionMetadata();
     
     // Only send updatable fields to API
     const apiUpdate = {
@@ -75,7 +75,7 @@ export class UpdateTranscriptionUseCase {
 
     // Update store immediately (optimistic update) 
     const transcriptionModel = new TranscriptionModel(updated);
-    state.setTranscription(transcriptionModel);
+    store.setTranscription(transcriptionModel);
 
     try {
       // Save to API

--- a/src/use-cases/update-transcription.ts
+++ b/src/use-cases/update-transcription.ts
@@ -5,15 +5,15 @@ import type { TranscriptionData } from '../types/shared';
 
 export interface UpdateTranscriptionConfig {
   transcriptionId: string;
-  updates: {
+  updates?: {
     title?: string;
     comments?: string;
     source?: string;
+    length?: number;
   };
   services: typeof services;
-  username?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  store?: any;
+  state: any;
 }
 
 export class UpdateTranscriptionUseCase {
@@ -28,16 +28,12 @@ export class UpdateTranscriptionUseCase {
       throw new Error('transcriptionId is required');
     }
 
-    if (!this.config.username) {
-      throw new Error('username is required');
-    }
-
-    if (!this.config.updates || Object.keys(this.config.updates).length === 0) {
-      throw new Error('updates are required');
+    if (!this.config.state) {
+      throw new Error('state is required');
     }
 
     // Check if title is provided and validate it
-    if (this.config.updates.title !== undefined) {
+    if (this.config.updates?.title !== undefined) {
       if (!this.config.updates.title || this.config.updates.title.trim() === '') {
         throw new Error('title cannot be empty');
       }
@@ -47,25 +43,46 @@ export class UpdateTranscriptionUseCase {
   async execute(): Promise<TranscriptionData> {
     this.validate();
 
-    const { transcriptionId, updates, username, store } = this.config;
+    const { transcriptionId, updates, state, services } = this.config;
 
-    // Add user tracking fields
-    const updateData = {
+    // Get current user from auth service
+    const user = services.authService.currentUser();
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
+
+    // Calculate the complete updated transcription
+    const currentTranscription = state.transcription;
+    if (!currentTranscription) {
+      throw new Error('No transcription found in state');
+    }
+
+        const { coverage } = state.calculateTranscriptionMetadata();
+    
+    // Only send updatable fields to API
+    const apiUpdate = {
       ...updates,
-      userLastUpdated: username,  // Keep username for display purposes
+      coverage,
+      userLastUpdated: user.username.split('@')[0], // Extract username part from email
       dateLastUpdated: new Date().toISOString(),
     };
 
-    try {
-      // Update transcription  
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = await this.config.services.transcriptionService.updateTranscription(transcriptionId, updateData as any);
+    // Create complete updated object for optimistic store update
+    const updated = {
+      ...currentTranscription,
+      ...apiUpdate,
+    };
 
-      // Update store with transcription wrapped in ADT model
-      if (store?.setTranscription) {
-        const transcriptionModel = new TranscriptionModel(result);
-        store.setTranscription(transcriptionModel);
-      }
+    // Update store immediately (optimistic update) 
+    const transcriptionModel = new TranscriptionModel(updated);
+    state.setTranscription(transcriptionModel);
+
+    try {
+      // Save to API
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await services.transcriptionService.updateTranscription(transcriptionId, apiUpdate as any);
+
+      // TODO: how to handle roll-back or conflict if this fails
 
       // Show success toast
       showToast('Transcription saved', 'success');


### PR DESCRIPTION
Couple fixes in this PR:

 * when the transcription first loads and wavesurfer is "ready", save the transcription length
 * when adding/updating/deleting regions, update the transcription details (coverage, lastuser, etc)
 * makes consistent use of `store` in use cases

