### PR TITLE
Fixes the missing "Add new +" transcription button on desktop

### DIFF
--- a/src/components/list/TranscriptionsList.tsx
+++ b/src/components/list/TranscriptionsList.tsx
@@ -302,15 +302,13 @@ export const TranscriptionsList = () => {
               <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
             </div>
             
-            {showUploadButton && (
-              <Link 
-                to="/transcribe-add" 
-                className="inline-flex items-center justify-center px-4 py-2 bg-ki-blue text-white text-sm font-medium rounded-md hover:bg-blue-700 transition-colors"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add New
-              </Link>
-            )}
+            <Link 
+              to="/transcribe-add" 
+              className="inline-flex items-center justify-center px-4 py-2 bg-ki-blue text-white text-sm font-medium rounded-md hover:bg-blue-700 transition-colors"
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              Add New
+            </Link>
             </div>
           </div>
         </div>

--- a/src/use-cases/create-region.ts
+++ b/src/use-cases/create-region.ts
@@ -22,6 +22,7 @@ export class CreateRegion {
     this.config = config;
   }
 
+
   validate(): void {
     if (!this.config.transcriptionId || this.config.transcriptionId.trim() === '') {
       throw new Error('transcriptionId is required and cannot be empty');


### PR DESCRIPTION
Shut off on mobile for now, accidentally shut off desktop. This was a hotfix, and is in production already.