### PR TITLE
Handle huge peaks files by chunking

### DIFF
--- a/amplify/backend/function/createPeaksFile/src/lib/audio.js
+++ b/amplify/backend/function/createPeaksFile/src/lib/audio.js
@@ -73,7 +73,7 @@ const processPeaksData = async (jsonPath) => {
   console.log(`Max peak value: ${max}`)
   
   // Normalize data using chunked processing to avoid stack overflow
-  parsed.data = processLargeArray(parsed.data, max)
+  parsed.data = processArrayInChunks(parsed.data, max)
   
   return parsed
 }
@@ -99,7 +99,7 @@ const getMaxValue = (arr) => {
  * @param {number} max - Maximum value for normalization
  * @returns {number[]} - Processed array
  */
-const processLargeArray = (data, max) => {
+const processArrayInChunks = (data, max) => {
   const chunkSize = 10000
   const result = []
   

--- a/amplify/backend/function/createPeaksFile/src/lib/audio.js
+++ b/amplify/backend/function/createPeaksFile/src/lib/audio.js
@@ -66,16 +66,59 @@ const processPeaksData = async (jsonPath) => {
     throw new Error('Array is empty or undefined')
   }
   
-  // Find maximum value for normalization
-  const max = Math.max(...parsed.data)
+  console.log(`Processing peaks data with ${parsed.data.length} elements`)
+  
+  // Find maximum value for normalization (avoid spread operator for large arrays)
+  const max = getMaxValue(parsed.data)
   console.log(`Max peak value: ${max}`)
   
-  // Normalize data to 0-1 range with 2 decimal places
-  parsed.data = parsed.data.map(value => {
-    return Number(Number(value / max).toFixed(2))
-  })
+  // Normalize data using chunked processing to avoid stack overflow
+  parsed.data = processLargeArray(parsed.data, max)
   
   return parsed
+}
+
+/**
+ * Find maximum value in array without using spread operator
+ * @param {number[]} arr - Array of numbers
+ * @returns {number} - Maximum value
+ */
+const getMaxValue = (arr) => {
+  let max = arr[0]
+  for (let i = 1; i < arr.length; i++) {
+    if (max < arr[i]) {
+      max = arr[i]
+    }
+  }
+  return max
+}
+
+/**
+ * Process large array in chunks to avoid stack overflow
+ * @param {number[]} data - Array to process
+ * @param {number} max - Maximum value for normalization
+ * @returns {number[]} - Processed array
+ */
+const processLargeArray = (data, max) => {
+  const chunkSize = 10000
+  const result = []
+  
+  for (let i = 0; i < data.length; i += chunkSize) {
+    const endIndex = Math.min(i + chunkSize, data.length)
+    
+    // Process chunk without using .map() to avoid stack issues
+    for (let j = i; j < endIndex; j++) {
+      result[j] = Number(Number(data[j] / max).toFixed(2))
+    }
+    
+    // Log progress for large arrays (every 50k elements)
+    if (i % 50000 === 0 && i > 0) {
+      console.log(`Processed ${endIndex} / ${data.length} elements`)
+    }
+  }
+  
+  console.log(`Completed processing ${result.length} elements`)
+  return result
 }
 
 /**


### PR DESCRIPTION
The old naiive code would just crap out with a massive (say 500kb) json file, this handles it in chunks for large peaks files.