### PR TITLE
Bust PWA cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
-        "vite-plugin-pwa": "^1.0.2"
+        "vite-plugin-pwa": "^1.0.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -15062,10 +15062,11 @@
       }
     },
     "node_modules/vite-plugin-pwa": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.0.2.tgz",
-      "integrity": "sha512-O3UwjsCnoDclgJANoOgzzqW7SFgwXE/th2OmUP/ILxHKwzWxxKDBu+B/Xa9Cv4IgSVSnj2HgRVIJ7F15+vQFkA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.0.3.tgz",
+      "integrity": "sha512-/OpqIpUldALGxcsEnv/ekQiQ5xHkQ53wcoN5ewX4jiIDNGs3W+eNcI1WYZeyOLmzoEjg09D7aX0O89YGjen1aw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.6",
         "pretty-bytes": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vite-plugin-pwa": "^1.0.2"
+    "vite-plugin-pwa": "^1.0.3"
   }
 }

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -134,6 +134,9 @@ export const AppLayout = () => {
                       <div className="text-sm font-medium text-gray-900 truncate">
                         {user?.username}
                       </div>
+                      <div className="text-xs text-gray-400 mt-1">
+                        Build: {import.meta.env.MODE === 'production' ? __BUILD_HASH__ : 'dev'}
+                      </div>
                     </div>
                     
                     <div className="py-1">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+// Build-time constants injected by Vite
+declare const __BUILD_HASH__: string;
+declare const __BUILD_TIME__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,27 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
+// Generate a short build hash (7 characters, like git commit)
+const generateBuildHash = () => {
+  const timestamp = Date.now().toString();
+  let hash = 0;
+  for (let i = 0; i < timestamp.length; i++) {
+    const char = timestamp.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return Math.abs(hash).toString(36).substring(0, 7);
+};
+
+const buildHash = generateBuildHash();
+const buildTime = new Date().toISOString();
+
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __BUILD_HASH__: JSON.stringify(buildHash),
+    __BUILD_TIME__: JSON.stringify(buildTime),
+  },
   plugins: [
     react(),
     VitePWA({
@@ -69,7 +88,9 @@ export default defineConfig({
         navigateFallbackDenylist: [/^\/_/, /\/[^/?]+\.[^/]+$/],
         offlineGoogleAnalytics: false,
         skipWaiting: true,
-        clientsClaim: true
+        clientsClaim: true,
+        cacheId: `kiyanaw-${buildHash}`,
+        cleanupOutdatedCaches: true
       },
       devOptions: {
         enabled: false  // Disable service worker in dev to avoid conflicts


### PR DESCRIPTION
Right now when we deploy, we have no way of knowing if the app is being cached in PWA mode (it is). This puts a small hash in the user menu (Build: abcdef) and then should help deployments bust the PWA service worker cache.

