### PR TITLE
Language database special processing

### DIFF
--- a/amplify/backend/function/indexRegionData/src/lib/search.js
+++ b/amplify/backend/function/indexRegionData/src/lib/search.js
@@ -1,6 +1,5 @@
 const assert = require('assert')
 
-const sapir = require('./sapir')
 const utils = require('../utils')
 const { getLanguageProcessor } = require('./special-processing')
 
@@ -45,12 +44,12 @@ const indexRegionAnalysis = async (region, transcription) => {
   }
   const languageCode = transcription.lang
 
-  // Use regionAnalysis array instead of parsing regionText for known words
-  const words = region.regionAnalysis || []
-  console.log('Words to index from regionAnalysis:', words)
+  // Use regionAnalysis array - now contains objects with {word, analysis}
+  const wordAnalyses = region.regionAnalysis || []
+  console.log('Word analyses to index from regionAnalysis:', wordAnalyses)
 
-  if (words.length === 0) {
-    console.log('No words in regionAnalysis to index')
+  if (wordAnalyses.length === 0) {
+    console.log('No word analyses in regionAnalysis to index')
     return
   }
 
@@ -63,75 +62,85 @@ const indexRegionAnalysis = async (region, transcription) => {
 
   // Get language-specific processor if available
   const languageProcessor = getLanguageProcessor(languageCode)
+  
+  if (!languageProcessor) {
+    console.log(`⚠️ No language processor found for language: ${languageCode}`)
+    return
+  }
+  
+  if (!languageProcessor.analyze) {
+    console.log(`⚠️ Language processor for ${languageCode} does not support analysis`)
+    return
+  }
 
   // Process words in parallel using Promise.allSettled for better performance
-  const wordProcessingPromises = words.map(async (word) => {
-    // Apply language-specific character processing if available
-    const surface = languageProcessor?.processCharacters 
-      ? languageProcessor.processCharacters(word)
-      : word
+  const wordProcessingPromises = wordAnalyses.map(async (wordAnalysis) => {
+    // Expect wordAnalysis to be {word: "foo", analysis: "lemma+POS+..."}
+    const rawWord = wordAnalysis.word
+    const analysisString = wordAnalysis.analysis
     
-    if (!surface) {
-      console.log('Skipping empty word after normalization:', word)
-      return { status: 'skipped', word, reason: 'empty after normalization' }
+    if (!rawWord || !analysisString) {
+      console.log('Skipping word analysis with missing data:', wordAnalysis)
+      return { status: 'skipped', word: rawWord, reason: 'missing word or analysis' }
     }
     
-    console.log('Processing word:', surface)
+    // Apply language-specific character processing to get the surface form
+    const surface = languageProcessor.processCharacters(rawWord)
+    
+    if (!surface) {
+      console.log('Skipping empty word after normalization:', rawWord)
+      return { status: 'skipped', word: rawWord, reason: 'empty after normalization' }
+    }
+    
+    console.log('Processing word:', surface, 'with analysis:', analysisString)
     
     try {
-      // TODO: check for IPC
-      // TODO: pull only wolvengrey
-      // TODO: exact-match results
-      const raw = await sapir.clickInText(surface)
-      const results = raw.data.results
+      // Use language-specific analyzer instead of SaPir
+      const analyzed = languageProcessor.analyze(analysisString)
+      const { lemma, wordType, wordClass } = analyzed
+      
+      if (!lemma) {
+        console.log(`No lemma found for word: ${surface} (analysis: ${analysisString})`)
+        return { status: 'no_lemma', word: surface, analysis: analysisString }
+      }
+      
+      console.log(`Got lemma for surface form '${surface}': ${lemma} (${wordClass})`)
 
-      if (results.length) {
-        const lemma = results[0].lemma_wordform.text
-        const wordType = results[0].lemma_wordform.pos
-        const wordClass = results[0].lemma_wordform.wordclass
-        console.log(`Got lemma for surface form '${surface}': ${lemma}`)
+      const toIndex = {
+        lang: languageCode, // Use transcription language
+        lemma,
+        surface,
+        transcriptionId: region.transcriptionId,
+        regionId: region.id,
+        regionText: languageProcessor.processCharacters(sentence),
+        wordType,
+        wordClass,
+        transcriptionName: transcription.title,
+        timestamp: `${region.start}:${region.end}`,
+      }
 
-        const toIndex = {
-          lang: languageCode, // Use transcription language
-          lemma,
-          surface,
-          transcriptionId: region.transcriptionId,
-          regionId: region.id,
-          regionText: languageProcessor?.processCharacters 
-            ? languageProcessor.processCharacters(sentence)
-            : sentence,
-          wordType,
-          wordClass,
-          transcriptionName: transcription.title,
-          timestamp: `${region.start}:${region.end}`,
-        }
-
-        const indexName = `knownwords-${process.env.ENV}`
-        const success = await client.update({
-          index: indexName,
-          id: `${toIndex.regionId}-${surface}`,
-          body: {
-            // put the partial document under the `doc` key
-            doc: toIndex,
-            doc_as_upsert: true,
-          },
-        })
-        
-        // OpenSearch client response structure - check for successful indexing
-        const isSuccessful = success.body?._shards?.successful > 0 || 
-                           success.statusCode === 200 || 
-                           success.statusCode === 201
-        
-        return { 
-          status: 'indexed', 
-          word: surface, 
-          lemma,
-          successful: isSuccessful,
-          response: success.body?.result || 'success'
-        }
-      } else {
-        console.log(`No results found for word: ${surface}`)
-        return { status: 'no_results', word: surface }
+      const indexName = `knownwords-${process.env.ENV}`
+      const success = await client.update({
+        index: indexName,
+        id: `${toIndex.regionId}-${surface}`,
+        body: {
+          // put the partial document under the `doc` key
+          doc: toIndex,
+          doc_as_upsert: true,
+        },
+      })
+      
+      // OpenSearch client response structure - check for successful indexing
+      const isSuccessful = success.body?._shards?.successful > 0 || 
+                         success.statusCode === 200 || 
+                         success.statusCode === 201
+      
+      return { 
+        status: 'indexed', 
+        word: surface, 
+        lemma,
+        successful: isSuccessful,
+        response: success.body?.result || 'success'
       }
     } catch (error) {
       console.error(`Error processing word "${surface}":`, error.message)
@@ -144,11 +153,12 @@ const indexRegionAnalysis = async (region, transcription) => {
   
   // Log summary of results
   const summary = {
-    total: words.length,
+    total: wordAnalyses.length,
     indexed: 0,
     failed: 0,
     skipped: 0,
-    no_results: 0
+    no_lemma: 0,
+    error: 0
   }
   
   results.forEach((result, index) => {
@@ -161,7 +171,7 @@ const indexRegionAnalysis = async (region, transcription) => {
       }
     } else {
       summary.failed++
-      console.error(`Promise rejected for word ${words[index]}:`, result.reason)
+      console.error(`Promise rejected for word ${wordAnalyses[index].word}:`, result.reason)
     }
   })
   

--- a/amplify/backend/function/indexRegionData/src/lib/search.js
+++ b/amplify/backend/function/indexRegionData/src/lib/search.js
@@ -113,6 +113,7 @@ const indexRegionAnalysis = async (region, transcription) => {
         transcriptionId: region.transcriptionId,
         regionId: region.id,
         regionText: languageProcessor.processCharacters(sentence),
+        translation: region.translation,
         wordType,
         wordClass,
         transcriptionName: transcription.title,

--- a/amplify/backend/function/indexRegionData/src/lib/search.js
+++ b/amplify/backend/function/indexRegionData/src/lib/search.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 
 const sapir = require('./sapir')
 const utils = require('../utils')
+const { getLanguageProcessor } = require('./special-processing')
 
 const { client } = require('./es')
 
@@ -60,11 +61,15 @@ const indexRegionAnalysis = async (region, transcription) => {
     sentence = region.regionText
   }
 
+  // Get language-specific processor if available
+  const languageProcessor = getLanguageProcessor(languageCode)
+
   // Process words in parallel using Promise.allSettled for better performance
   const wordProcessingPromises = words.map(async (word) => {
-    let surface = utils.toCircumflex(word)
-    // strip out any goofy characters
-    surface = surface.replace(/[.,\/#!$%\^&\*;:{}=_`~()]/g, '').trim()
+    // Apply language-specific character processing if available
+    const surface = languageProcessor?.processCharacters 
+      ? languageProcessor.processCharacters(word)
+      : word
     
     if (!surface) {
       console.log('Skipping empty word after normalization:', word)
@@ -92,7 +97,9 @@ const indexRegionAnalysis = async (region, transcription) => {
           surface,
           transcriptionId: region.transcriptionId,
           regionId: region.id,
-          regionText: utils.toCircumflex(sentence),
+          regionText: languageProcessor?.processCharacters 
+            ? languageProcessor.processCharacters(sentence)
+            : sentence,
           wordType,
           wordClass,
           transcriptionName: transcription.title,

--- a/amplify/backend/function/indexRegionData/src/lib/special-processing-crk.js
+++ b/amplify/backend/function/indexRegionData/src/lib/special-processing-crk.js
@@ -53,7 +53,7 @@ const processCharacters = (text) => {
  * // Returns: { lemma: "ahcahk", wordType: "N", wordClass: "NA" }
  * 
  * analyze("êkây+Ipc")
- * // Returns: { lemma: "êkây", wordType: "Ipc", wordClass: "Ipc" }
+ * // Returns: { lemma: "êkây", wordType: "Ipc", wordClass: "IPC" }
  */
 const analyze = (analysis) => {
   // Handle null, undefined, or empty strings
@@ -126,11 +126,11 @@ const analyze = (analysis) => {
       break
     } else if (tag === 'Ipc') {
       wordType = 'Ipc'
-      wordClass = 'Ipc'
+      wordClass = 'IPC'
       break
     } else if (tag === 'Pron') {
       wordType = 'Pron'
-      wordClass = 'Pron'
+      wordClass = 'PRON'
       break
     }
   }

--- a/amplify/backend/function/indexRegionData/src/lib/special-processing-crk.js
+++ b/amplify/backend/function/indexRegionData/src/lib/special-processing-crk.js
@@ -1,0 +1,149 @@
+/**
+ * Special processing functions for Plains Cree (crk) language
+ * 
+ * These functions handle CRK-specific text normalization and processing
+ */
+
+/**
+ * Converts macron diacritics to circumflex diacritics and strips punctuation
+ * This is standard normalization for Plains Cree orthography
+ * 
+ * @param {string} text - The text to process
+ * @returns {string} - Normalized text with circumflex diacritics and no punctuation
+ */
+const processCharacters = (text) => {
+  if (!text || typeof text !== 'string') {
+    return text
+  }
+  
+  return text
+    .replace(/ā/g, 'â')
+    .replace(/ī/g, 'î')
+    .replace(/ō/g, 'ô')
+    .replace(/ē/g, 'ê')
+    .replace(/[.,\/#!$%\^&\*;:{}=_`~()]/g, '')
+    .trim()
+}
+
+/**
+ * Analyzes a CRK linguistic analysis string and extracts lemma, wordType, and wordClass
+ * 
+ * Analysis strings follow the format:
+ *   [PREFIX+]lemma+POS[+SUBCLASS][+OTHER_TAGS]
+ * 
+ * Where PREFIX can be:
+ *   - PV/ (preverb)
+ *   - IC+ (initial change)
+ *   - RdplW+ or RdplS+ (reduplication)
+ * 
+ * POS (Part of Speech):
+ *   - V (verb) with subclasses: AI, II, TA, TI
+ *   - N (noun) with subclasses: A (animate), I (inanimate)
+ *   - Ipc (particle)
+ *   - Pron (pronoun)
+ * 
+ * @param {string} analysis - The linguistic analysis string (e.g., "PV/ati+ohpikihtâw+V+TI+Imp+Imm+2Sg")
+ * @returns {Object} - Object with {lemma, wordType, wordClass}
+ * 
+ * @example
+ * analyze("PV/ati+ohpikihtâw+V+TI+Imp+Imm+2Sg")
+ * // Returns: { lemma: "ohpikihtâw", wordType: "V", wordClass: "VTI" }
+ * 
+ * analyze("ahcahk+N+A+Sg")
+ * // Returns: { lemma: "ahcahk", wordType: "N", wordClass: "NA" }
+ * 
+ * analyze("êkây+Ipc")
+ * // Returns: { lemma: "êkây", wordType: "Ipc", wordClass: "Ipc" }
+ */
+const analyze = (analysis) => {
+  // Handle null, undefined, or empty strings
+  if (!analysis || typeof analysis !== 'string' || analysis.trim() === '') {
+    return {
+      lemma: null,
+      wordType: null,
+      wordClass: null
+    }
+  }
+
+  // Split the analysis string by '+'
+  const parts = analysis.split('+')
+  
+  // Find the lemma - first part that doesn't start with a special prefix
+  let lemma = null
+  let lemmaIndex = -1
+  const prefixes = ['PV/', 'IC', 'RdplW', 'RdplS']
+  
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i]
+    const hasPrefix = prefixes.some(prefix => part.startsWith(prefix))
+    
+    if (!hasPrefix && lemma === null) {
+      lemma = part
+      lemmaIndex = i
+      break
+    }
+  }
+  
+  // If no lemma found (shouldn't happen with valid input), return the first part
+  if (lemma === null && parts.length > 0) {
+    lemma = parts[0]
+    lemmaIndex = 0
+  }
+  
+  // Find the part of speech (comes after the lemma)
+  let wordType = null
+  let wordClass = null
+  
+  // Look at tags after the lemma
+  for (let i = lemmaIndex + 1; i < parts.length; i++) {
+    const tag = parts[i]
+    
+    // Check for main part of speech tags
+    if (tag === 'V') {
+      wordType = 'V'
+      // Look for verb subclass in next tag
+      if (i + 1 < parts.length) {
+        const nextTag = parts[i + 1]
+        if (nextTag === 'AI') wordClass = 'VAI'
+        else if (nextTag === 'II') wordClass = 'VII'
+        else if (nextTag === 'TA') wordClass = 'VTA'
+        else if (nextTag === 'TI') wordClass = 'VTI'
+      }
+      break
+    } else if (tag === 'N') {
+      wordType = 'N'
+      // Look for noun subclass - could be next tag or one after (if 'D' for dependent comes first)
+      for (let j = i + 1; j < parts.length && j < i + 3; j++) {
+        const nextTag = parts[j]
+        if (nextTag === 'A') {
+          wordClass = 'NA'
+          break
+        } else if (nextTag === 'I') {
+          wordClass = 'NI'
+          break
+        }
+      }
+      break
+    } else if (tag === 'Ipc') {
+      wordType = 'Ipc'
+      wordClass = 'Ipc'
+      break
+    } else if (tag === 'Pron') {
+      wordType = 'Pron'
+      wordClass = 'Pron'
+      break
+    }
+  }
+  
+  return {
+    lemma,
+    wordType,
+    wordClass
+  }
+}
+
+module.exports = {
+  processCharacters,
+  analyze,
+}
+

--- a/amplify/backend/function/indexRegionData/src/lib/special-processing-crk.test.js
+++ b/amplify/backend/function/indexRegionData/src/lib/special-processing-crk.test.js
@@ -1,0 +1,430 @@
+const { processCharacters, analyze } = require('./special-processing-crk')
+
+describe('special-processing-crk', () => {
+  describe('processCharacters', () => {
+    it('converts macron to circumflex', () => {
+      expect(processCharacters('ā')).toBe('â')
+      expect(processCharacters('ī')).toBe('î')
+      expect(processCharacters('ō')).toBe('ô')
+      expect(processCharacters('ē')).toBe('ê')
+    })
+
+    it('strips punctuation', () => {
+      expect(processCharacters('hello,')).toBe('hello')
+      expect(processCharacters('test.')).toBe('test')
+      expect(processCharacters('word!')).toBe('word')
+    })
+
+    it('handles null and undefined', () => {
+      expect(processCharacters(null)).toBe(null)
+      expect(processCharacters(undefined)).toBe(undefined)
+    })
+  })
+
+  describe('analyze', () => {
+    describe('particles (Ipc)', () => {
+      it('parses simple particles', () => {
+        expect(analyze('â+Ipc+Interj')).toEqual({
+          lemma: 'â',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+
+        expect(analyze('âhâ+Ipc+Interj')).toEqual({
+          lemma: 'âhâ',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+
+        expect(analyze('ahpô+Ipc')).toEqual({
+          lemma: 'ahpô',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+      })
+
+      it('parses particles without additional tags', () => {
+        expect(analyze('anima+Ipc')).toEqual({
+          lemma: 'anima',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+
+        expect(analyze('êkây+Ipc')).toEqual({
+          lemma: 'êkây',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+      })
+    })
+
+    describe('animate nouns (NA)', () => {
+      it('parses animate nouns', () => {
+        expect(analyze('ahcahk+N+A+Sg')).toEqual({
+          lemma: 'ahcahk',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('âhâsiw+N+A+Sg')).toEqual({
+          lemma: 'âhâsiw',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('awâsis+N+A+Obv')).toEqual({
+          lemma: 'awâsis',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('nêhiyaw+N+A+Sg')).toEqual({
+          lemma: 'nêhiyaw',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+      })
+
+      it('parses animate nouns with possessive', () => {
+        expect(analyze('wâhkômâkan+N+A+Px2Sg+Pl')).toEqual({
+          lemma: 'wâhkômâkan',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('nôsisim+N+A+D+Px2Sg+Sg')).toEqual({
+          lemma: 'nôsisim',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+      })
+    })
+
+    describe('inanimate nouns (NI)', () => {
+      it('parses inanimate nouns', () => {
+        expect(analyze('apasoy+N+I+Sg')).toEqual({
+          lemma: 'apasoy',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+
+        expect(analyze('mihti+N+I+Sg')).toEqual({
+          lemma: 'mihti',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+
+        expect(analyze('mîkiwâhp+N+I+Sg')).toEqual({
+          lemma: 'mîkiwâhp',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+      })
+
+      it('parses inanimate nouns with locative', () => {
+        expect(analyze('akâmaskiy+N+I+Loc')).toEqual({
+          lemma: 'akâmaskiy',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+
+        expect(analyze('ôcênâs+N+I+Loc')).toEqual({
+          lemma: 'ôcênâs',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+      })
+    })
+
+    describe('animate intransitive verbs (VAI)', () => {
+      it('parses VAI verbs', () => {
+        expect(analyze('âhkamêyimow+V+AI+Ind+1Sg')).toEqual({
+          lemma: 'âhkamêyimow',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+awasêwêw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'awasêwêw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('IC+nahîw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'nahîw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+      })
+
+      it('parses VAI verbs with preverbs', () => {
+        expect(analyze('PV/ati+ohpîw+V+AI+Imp+Imm+2Sg')).toEqual({
+          lemma: 'ohpîw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+PV/ki+manîw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'manîw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+PV/wi+isîhcikêw+V+AI+Cnj+3Pl')).toEqual({
+          lemma: 'isîhcikêw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+      })
+
+      it('parses VAI verbs with multiple preverbs', () => {
+        expect(analyze('PV/e+PV/ki+PV/nihta+kâsôw+V+AI+Cnj+3Pl')).toEqual({
+          lemma: 'kâsôw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+PV/ki+PV/pimi+itinikêw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'itinikêw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+      })
+
+      it('parses VAI verbs with reduplication', () => {
+        expect(analyze('PV/e+RdplW+papâmipahtâw+V+AI+Cnj+3Pl')).toEqual({
+          lemma: 'papâmipahtâw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('RdplW+kaskihtâw+V+TI+Imp+Imm+2Sg')).toEqual({
+          lemma: 'kaskihtâw',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+      })
+    })
+
+    describe('inanimate intransitive verbs (VII)', () => {
+      it('parses VII verbs', () => {
+        expect(analyze('PV/e+ispahcâw+V+II+Cnj+4Sg')).toEqual({
+          lemma: 'ispahcâw',
+          wordType: 'V',
+          wordClass: 'VII'
+        })
+
+        expect(analyze('PV/kaa+ohpîw+V+II+Cnj+3Pl')).toEqual({
+          lemma: 'ohpîw',
+          wordType: 'V',
+          wordClass: 'VII'
+        })
+
+        expect(analyze('PV/e+PV/ati+wâpan+V+II+Cnj+4Sg')).toEqual({
+          lemma: 'wâpan',
+          wordType: 'V',
+          wordClass: 'VII'
+        })
+      })
+    })
+
+    describe('transitive animate verbs (VTA)', () => {
+      it('parses VTA verbs', () => {
+        expect(analyze('ahêw+V+TA+Ind+3Sg+1SgO')).toEqual({
+          lemma: 'ahêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+
+        expect(analyze('IC+PV/ako+ayâwêw+V+TA+Cnj+X+3PlO')).toEqual({
+          lemma: 'ayâwêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+
+        expect(analyze('PV/e+nôtinêw+V+TA+Cnj+3Sg+1SgO')).toEqual({
+          lemma: 'nôtinêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+      })
+
+      it('parses VTA verbs with preverbs', () => {
+        expect(analyze('PV/e+PV/ki+osâpamêw+V+TA+Cnj+2Sg+3PlO')).toEqual({
+          lemma: 'osâpamêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+
+        expect(analyze('PV/kaa+PV/ki+âsônamawêw+V+TA+Cnj+X+3PlO')).toEqual({
+          lemma: 'âsônamawêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+      })
+
+      it('parses VTA verbs with reduplication', () => {
+        expect(analyze('RdplW+kakwêcimêw+V+TA+Imp+Imm+2Pl+3PlO')).toEqual({
+          lemma: 'kakwêcimêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+
+        expect(analyze('RdplW+kâtêw+V+TA+Imp+Imm+2Sg+3PlO')).toEqual({
+          lemma: 'kâtêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+      })
+    })
+
+    describe('transitive inanimate verbs (VTI)', () => {
+      it('parses VTI verbs', () => {
+        expect(analyze('nahitôtam+V+TI+Ind+1Sg')).toEqual({
+          lemma: 'nahitôtam',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+
+        expect(analyze('PV/ati+ohpikihtâw+V+TI+Imp+Imm+2Sg')).toEqual({
+          lemma: 'ohpikihtâw',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+
+        expect(analyze('PV/e+itêyihtam+V+TI+Cnj+3Pl')).toEqual({
+          lemma: 'itêyihtam',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+      })
+
+      it('parses VTI verbs with preverbs', () => {
+        expect(analyze('PV/e+PV/ki+âpacihtâw+V+TI+Cnj+3Sg')).toEqual({
+          lemma: 'âpacihtâw',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+
+        expect(analyze('PV/kaa+PV/ki+wêhcihtâw+V+TI+Cnj+2Pl')).toEqual({
+          lemma: 'wêhcihtâw',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+      })
+
+      it('parses VTI verbs with reduplication', () => {
+        expect(analyze('PV/e+RdplW+tasîhtam+V+TI+Cnj+4Sg/Pl')).toEqual({
+          lemma: 'tasîhtam',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+
+        expect(analyze('RdplW+nitohtam+V+TI+Ind+1Sg')).toEqual({
+          lemma: 'nitohtam',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+      })
+    })
+
+    describe('pronouns', () => {
+      it('parses pronouns', () => {
+        expect(analyze('awiyak+Pron+Indef+A+Sg')).toEqual({
+          lemma: 'awiyak',
+          wordType: 'Pron',
+          wordClass: 'Pron'
+        })
+
+        expect(analyze('ôhi+Pron+Dem+Prox+I+Pl')).toEqual({
+          lemma: 'ôhi',
+          wordType: 'Pron',
+          wordClass: 'Pron'
+        })
+      })
+    })
+
+    describe('edge cases', () => {
+      it('handles empty or invalid input', () => {
+        expect(analyze('')).toEqual({
+          lemma: null,
+          wordType: null,
+          wordClass: null
+        })
+
+        expect(analyze(null)).toEqual({
+          lemma: null,
+          wordType: null,
+          wordClass: null
+        })
+
+        expect(analyze(undefined)).toEqual({
+          lemma: null,
+          wordType: null,
+          wordClass: null
+        })
+      })
+
+      it('handles malformed analysis strings', () => {
+        expect(analyze('just-a-word')).toEqual({
+          lemma: 'just-a-word',
+          wordType: null,
+          wordClass: null
+        })
+      })
+
+      it('handles analysis with derivational morphology', () => {
+        expect(analyze('iskwêcâkan+N+A+Der/Dim+N+A+Obv')).toEqual({
+          lemma: 'iskwêcâkan',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('miyi+N+I+Der/Dim+N+I+Pl')).toEqual({
+          lemma: 'miyi',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+      })
+
+      it('handles dependent nouns (D tag)', () => {
+        expect(analyze('misit+N+I+D+Px1Sg+Sg')).toEqual({
+          lemma: 'misit',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+
+        expect(analyze('nîstâw+N+A+D+Px2Sg+Obv')).toEqual({
+          lemma: 'nîstâw',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+      })
+    })
+
+    describe('complex preverb combinations', () => {
+      it('handles multiple PV and reduplication together', () => {
+        expect(analyze('PV/e+PV/isi+RdplW+ispiciw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'ispiciw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+PV/ki+RdplW+natopayiw+V+AI+Cnj+3Pl')).toEqual({
+          lemma: 'natopayiw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+      })
+
+      it('handles IC with preverbs', () => {
+        expect(analyze('IC+PV/ako+ayâwêw+V+TA+Cnj+X+3PlO')).toEqual({
+          lemma: 'ayâwêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+      })
+    })
+  })
+})
+

--- a/amplify/backend/function/indexRegionData/src/lib/special-processing.js
+++ b/amplify/backend/function/indexRegionData/src/lib/special-processing.js
@@ -1,0 +1,48 @@
+/**
+ * Language-specific special processing registry
+ * 
+ * This module provides a centralized registry for language-specific
+ * text processing functions. Each language can define its own
+ * special processing logic.
+ * 
+ * Usage:
+ *   const processor = getLanguageProcessor('crk')
+ *   if (processor) {
+ *     const processed = processor.processCharacters(text)
+ *   }
+ */
+
+const languages = {
+  crk: require('./special-processing-crk'),
+}
+
+/**
+ * Get the special processor for a given language code
+ * 
+ * @param {string} languageCode - ISO 639-3 language code (e.g., 'crk')
+ * @returns {Object|null} - Language processor object or null if not found
+ */
+const getLanguageProcessor = (languageCode) => {
+  if (!languageCode || typeof languageCode !== 'string') {
+    return null
+  }
+  
+  return languages[languageCode] || null
+}
+
+/**
+ * Check if a language has special processing available
+ * 
+ * @param {string} languageCode - ISO 639-3 language code
+ * @returns {boolean} - True if special processing is available
+ */
+const hasSpecialProcessing = (languageCode) => {
+  return !!languages[languageCode]
+}
+
+module.exports = {
+  getLanguageProcessor,
+  hasSpecialProcessing,
+  languages, // Export for testing purposes
+}
+

--- a/amplify/backend/function/indexRegionData/src/test/test-search-integration.js
+++ b/amplify/backend/function/indexRegionData/src/test/test-search-integration.js
@@ -1,0 +1,455 @@
+/**
+ * Integration tests for search.js
+ * Tests the complete flow of indexing region analysis with language-specific processing
+ */
+
+const { indexRegionAnalysis, clearKnownWordsForRegion } = require('../lib/search')
+
+// Mock the OpenSearch client
+jest.mock('../lib/es', () => ({
+  client: {
+    update: jest.fn(),
+    deleteByQuery: jest.fn(),
+  }
+}))
+
+const { client } = require('../lib/es')
+
+describe('search.js integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Default successful response for OpenSearch
+    client.update.mockResolvedValue({
+      body: {
+        _shards: { successful: 1 },
+        result: 'updated'
+      },
+      statusCode: 200
+    })
+    client.deleteByQuery.mockResolvedValue({
+      body: { deleted: 5 }
+    })
+  })
+
+  describe('indexRegionAnalysis', () => {
+    it('should skip indexing if transcription has no language set', async () => {
+      const region = {
+        id: 'region-123',
+        transcriptionId: 'trans-123',
+        regionAnalysis: [
+          { word: 'êkây', analysis: 'êkây+Ipc' }
+        ],
+        regionText: 'êkây',
+        start: 0,
+        end: 1
+      }
+
+      const transcription = {
+        title: 'Test Transcription',
+        lang: null // No language set
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      // Should not call OpenSearch
+      expect(client.update).not.toHaveBeenCalled()
+    })
+
+    it('should skip indexing if regionAnalysis is empty', async () => {
+      const region = {
+        id: 'region-123',
+        transcriptionId: 'trans-123',
+        regionAnalysis: [],
+        regionText: '',
+        start: 0,
+        end: 1
+      }
+
+      const transcription = {
+        title: 'Test Transcription',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      expect(client.update).not.toHaveBeenCalled()
+    })
+
+    it('should skip indexing if language processor is not available', async () => {
+      const region = {
+        id: 'region-123',
+        transcriptionId: 'trans-123',
+        regionAnalysis: [
+          { word: 'test', analysis: 'test+N' }
+        ],
+        regionText: 'test',
+        start: 0,
+        end: 1
+      }
+
+      const transcription = {
+        title: 'Test Transcription',
+        lang: 'xyz' // Unsupported language
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      expect(client.update).not.toHaveBeenCalled()
+    })
+
+    it('should index CRK particles correctly', async () => {
+      const region = {
+        id: 'region-123',
+        transcriptionId: 'trans-123',
+        regionAnalysis: [
+          { word: 'êkây', analysis: 'êkây+Ipc' },
+          { word: 'âhâ', analysis: 'âhâ+Ipc+Interj' }
+        ],
+        regionText: 'êkây âhâ',
+        start: 0,
+        end: 2.5
+      }
+
+      const transcription = {
+        title: 'Test Transcription',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      expect(client.update).toHaveBeenCalledTimes(2)
+
+      // Check first word
+      expect(client.update).toHaveBeenCalledWith({
+        index: 'knownwords-undefined',
+        id: 'region-123-êkây',
+        body: {
+          doc: {
+            lang: 'crk',
+            lemma: 'êkây',
+            surface: 'êkây',
+            transcriptionId: 'trans-123',
+            regionId: 'region-123',
+            regionText: 'êkây âhâ',
+            wordType: 'Ipc',
+            wordClass: 'IPC',
+            transcriptionName: 'Test Transcription',
+            timestamp: '0:2.5'
+          },
+          doc_as_upsert: true
+        }
+      })
+
+      // Check second word
+      expect(client.update).toHaveBeenCalledWith({
+        index: 'knownwords-undefined',
+        id: 'region-123-âhâ',
+        body: {
+          doc: {
+            lang: 'crk',
+            lemma: 'âhâ',
+            surface: 'âhâ',
+            transcriptionId: 'trans-123',
+            regionId: 'region-123',
+            regionText: 'êkây âhâ',
+            wordType: 'Ipc',
+            wordClass: 'IPC',
+            transcriptionName: 'Test Transcription',
+            timestamp: '0:2.5'
+          },
+          doc_as_upsert: true
+        }
+      })
+    })
+
+    it('should index CRK nouns correctly', async () => {
+      const region = {
+        id: 'region-456',
+        transcriptionId: 'trans-456',
+        regionAnalysis: [
+          { word: 'nêhiyaw', analysis: 'nêhiyaw+N+A+Sg' },
+          { word: 'mîkiwâhp', analysis: 'mîkiwâhp+N+I+Sg' }
+        ],
+        regionText: 'nêhiyaw mîkiwâhp',
+        start: 5.0,
+        end: 8.5
+      }
+
+      const transcription = {
+        title: 'Noun Test',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      expect(client.update).toHaveBeenCalledTimes(2)
+
+      // Check animate noun
+      const firstCall = client.update.mock.calls[0][0]
+      expect(firstCall.body.doc).toMatchObject({
+        lemma: 'nêhiyaw',
+        surface: 'nêhiyaw',
+        wordType: 'N',
+        wordClass: 'NA'
+      })
+
+      // Check inanimate noun
+      const secondCall = client.update.mock.calls[1][0]
+      expect(secondCall.body.doc).toMatchObject({
+        lemma: 'mîkiwâhp',
+        surface: 'mîkiwâhp',
+        wordType: 'N',
+        wordClass: 'NI'
+      })
+    })
+
+    it('should index CRK verbs with preverbs correctly', async () => {
+      const region = {
+        id: 'region-789',
+        transcriptionId: 'trans-789',
+        regionAnalysis: [
+          { word: 'ati-ohpikitâw', analysis: 'PV/ati+ohpikihtâw+V+TI+Ind+3Sg' },
+          { word: 'ê-awâsîwit', analysis: 'PV/e+awasêwêw+V+AI+Cnj+3Sg' }
+        ],
+        regionText: 'ati-ohpikitâw ê-awâsîwit',
+        start: 10.0,
+        end: 14.0
+      }
+
+      const transcription = {
+        title: 'Verb Test',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      expect(client.update).toHaveBeenCalledTimes(2)
+
+      // Check VTI verb
+      const firstCall = client.update.mock.calls[0][0]
+      expect(firstCall.body.doc).toMatchObject({
+        lemma: 'ohpikihtâw',
+        wordType: 'V',
+        wordClass: 'VTI'
+      })
+
+      // Check VAI verb
+      const secondCall = client.update.mock.calls[1][0]
+      expect(secondCall.body.doc).toMatchObject({
+        lemma: 'awasêwêw',
+        wordType: 'V',
+        wordClass: 'VAI'
+      })
+    })
+
+    it('should apply character processing (macron to circumflex)', async () => {
+      const region = {
+        id: 'region-111',
+        transcriptionId: 'trans-111',
+        regionAnalysis: [
+          { word: 'nēhiyāw', analysis: 'nêhiyaw+N+A+Sg' } // macrons in input
+        ],
+        regionText: 'nēhiyāw',
+        start: 0,
+        end: 1
+      }
+
+      const transcription = {
+        title: 'Character Processing Test',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      expect(client.update).toHaveBeenCalledTimes(1)
+
+      // Should convert macrons to circumflex
+      const call = client.update.mock.calls[0][0]
+      expect(call.body.doc.surface).toBe('nêhiyâw')
+      expect(call.body.doc.regionText).toBe('nêhiyâw')
+    })
+
+    it('should strip punctuation from words', async () => {
+      const region = {
+        id: 'region-222',
+        transcriptionId: 'trans-222',
+        regionAnalysis: [
+          { word: 'êkây,', analysis: 'êkây+Ipc' },
+          { word: 'nêhiyaw.', analysis: 'nêhiyaw+N+A+Sg' }
+        ],
+        regionText: 'êkây, nêhiyaw.',
+        start: 0,
+        end: 2
+      }
+
+      const transcription = {
+        title: 'Punctuation Test',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      expect(client.update).toHaveBeenCalledTimes(2)
+
+      // Check punctuation is stripped
+      expect(client.update.mock.calls[0][0].body.doc.surface).toBe('êkây')
+      expect(client.update.mock.calls[1][0].body.doc.surface).toBe('nêhiyaw')
+    })
+
+    it('should skip words with missing analysis', async () => {
+      const region = {
+        id: 'region-333',
+        transcriptionId: 'trans-333',
+        regionAnalysis: [
+          { word: 'êkây', analysis: 'êkây+Ipc' },
+          { word: 'test', analysis: null }, // Missing analysis
+          { word: 'nêhiyaw', analysis: 'nêhiyaw+N+A+Sg' }
+        ],
+        regionText: 'êkây test nêhiyaw',
+        start: 0,
+        end: 3
+      }
+
+      const transcription = {
+        title: 'Missing Analysis Test',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      // Should only index 2 words (skipping the one with no analysis)
+      expect(client.update).toHaveBeenCalledTimes(2)
+      expect(client.update.mock.calls[0][0].body.doc.lemma).toBe('êkây')
+      expect(client.update.mock.calls[1][0].body.doc.lemma).toBe('nêhiyaw')
+    })
+
+    it('should skip words that become empty after processing', async () => {
+      const region = {
+        id: 'region-444',
+        transcriptionId: 'trans-444',
+        regionAnalysis: [
+          { word: 'êkây', analysis: 'êkây+Ipc' },
+          { word: '...', analysis: 'unknown+N' }, // Will be empty after punctuation removal
+          { word: 'nêhiyaw', analysis: 'nêhiyaw+N+A+Sg' }
+        ],
+        regionText: 'êkây ... nêhiyaw',
+        start: 0,
+        end: 3
+      }
+
+      const transcription = {
+        title: 'Empty Word Test',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      // Should only index 2 words (skipping the punctuation-only word)
+      expect(client.update).toHaveBeenCalledTimes(2)
+    })
+
+    it('should handle complex analysis strings with multiple preverbs', async () => {
+      const region = {
+        id: 'region-555',
+        transcriptionId: 'trans-555',
+        regionAnalysis: [
+          { 
+            word: 'ê-kî-nîhtâ-kâsôcik', 
+            analysis: 'PV/e+PV/ki+PV/nihta+kâsôw+V+AI+Cnj+3Pl' 
+          }
+        ],
+        regionText: 'ê-kî-nîhtâ-kâsôcik',
+        start: 0,
+        end: 2
+      }
+
+      const transcription = {
+        title: 'Complex Analysis Test',
+        lang: 'crk'
+      }
+
+      await indexRegionAnalysis(region, transcription)
+
+      expect(client.update).toHaveBeenCalledTimes(1)
+
+      // Should extract the verb stem correctly
+      const call = client.update.mock.calls[0][0]
+      expect(call.body.doc).toMatchObject({
+        lemma: 'kâsôw',
+        wordType: 'V',
+        wordClass: 'VAI'
+      })
+    })
+
+    it('should handle OpenSearch errors gracefully', async () => {
+      const region = {
+        id: 'region-666',
+        transcriptionId: 'trans-666',
+        regionAnalysis: [
+          { word: 'êkây', analysis: 'êkây+Ipc' },
+          { word: 'nêhiyaw', analysis: 'nêhiyaw+N+A+Sg' }
+        ],
+        regionText: 'êkây nêhiyaw',
+        start: 0,
+        end: 2
+      }
+
+      const transcription = {
+        title: 'Error Test',
+        lang: 'crk'
+      }
+
+      // Make first call fail
+      client.update
+        .mockRejectedValueOnce(new Error('OpenSearch connection failed'))
+        .mockResolvedValueOnce({
+          body: { _shards: { successful: 1 } },
+          statusCode: 200
+        })
+
+      await indexRegionAnalysis(region, transcription)
+
+      // Should have attempted both, one failed, one succeeded
+      expect(client.update).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('clearKnownWordsForRegion', () => {
+    it('should clear words for a region', async () => {
+      await clearKnownWordsForRegion('region-123')
+
+      expect(client.deleteByQuery).toHaveBeenCalledWith({
+        index: 'knownwords-undefined',
+        body: {
+          query: {
+            term: { regionId: 'region-123' }
+          }
+        }
+      })
+    })
+
+    it('should throw error for invalid regionId', async () => {
+      await expect(clearKnownWordsForRegion(null)).rejects.toThrow('Invalid regionId')
+      await expect(clearKnownWordsForRegion('')).rejects.toThrow('Invalid regionId')
+      await expect(clearKnownWordsForRegion(123)).rejects.toThrow('Invalid regionId')
+    })
+
+    it('should handle index not found gracefully', async () => {
+      client.deleteByQuery.mockRejectedValueOnce({
+        meta: {
+          statusCode: 404,
+          body: {
+            error: {
+              type: 'index_not_found_exception'
+            }
+          }
+        }
+      })
+
+      const result = await clearKnownWordsForRegion('region-123')
+
+      expect(result).toEqual({ deleted: 0 })
+    })
+  })
+})
+

--- a/amplify/backend/function/indexRegionData/src/test/test-special-processing-crk.js
+++ b/amplify/backend/function/indexRegionData/src/test/test-special-processing-crk.js
@@ -1,0 +1,430 @@
+const { processCharacters, analyze } = require('../lib/special-processing-crk')
+
+describe('special-processing-crk', () => {
+  describe('processCharacters', () => {
+    it('converts macron to circumflex', () => {
+      expect(processCharacters('ā')).toBe('â')
+      expect(processCharacters('ī')).toBe('î')
+      expect(processCharacters('ō')).toBe('ô')
+      expect(processCharacters('ē')).toBe('ê')
+    })
+
+    it('strips punctuation', () => {
+      expect(processCharacters('hello,')).toBe('hello')
+      expect(processCharacters('test.')).toBe('test')
+      expect(processCharacters('word!')).toBe('word')
+    })
+
+    it('handles null and undefined', () => {
+      expect(processCharacters(null)).toBe(null)
+      expect(processCharacters(undefined)).toBe(undefined)
+    })
+  })
+
+  describe('analyze', () => {
+    describe('particles (Ipc)', () => {
+      it('parses simple particles', () => {
+        expect(analyze('â+Ipc+Interj')).toEqual({
+          lemma: 'â',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+
+        expect(analyze('âhâ+Ipc+Interj')).toEqual({
+          lemma: 'âhâ',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+
+        expect(analyze('ahpô+Ipc')).toEqual({
+          lemma: 'ahpô',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+      })
+
+      it('parses particles without additional tags', () => {
+        expect(analyze('anima+Ipc')).toEqual({
+          lemma: 'anima',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+
+        expect(analyze('êkây+Ipc')).toEqual({
+          lemma: 'êkây',
+          wordType: 'Ipc',
+          wordClass: 'Ipc'
+        })
+      })
+    })
+
+    describe('animate nouns (NA)', () => {
+      it('parses animate nouns', () => {
+        expect(analyze('ahcahk+N+A+Sg')).toEqual({
+          lemma: 'ahcahk',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('âhâsiw+N+A+Sg')).toEqual({
+          lemma: 'âhâsiw',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('awâsis+N+A+Obv')).toEqual({
+          lemma: 'awâsis',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('nêhiyaw+N+A+Sg')).toEqual({
+          lemma: 'nêhiyaw',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+      })
+
+      it('parses animate nouns with possessive', () => {
+        expect(analyze('wâhkômâkan+N+A+Px2Sg+Pl')).toEqual({
+          lemma: 'wâhkômâkan',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('nôsisim+N+A+D+Px2Sg+Sg')).toEqual({
+          lemma: 'nôsisim',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+      })
+    })
+
+    describe('inanimate nouns (NI)', () => {
+      it('parses inanimate nouns', () => {
+        expect(analyze('apasoy+N+I+Sg')).toEqual({
+          lemma: 'apasoy',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+
+        expect(analyze('mihti+N+I+Sg')).toEqual({
+          lemma: 'mihti',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+
+        expect(analyze('mîkiwâhp+N+I+Sg')).toEqual({
+          lemma: 'mîkiwâhp',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+      })
+
+      it('parses inanimate nouns with locative', () => {
+        expect(analyze('akâmaskiy+N+I+Loc')).toEqual({
+          lemma: 'akâmaskiy',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+
+        expect(analyze('ôcênâs+N+I+Loc')).toEqual({
+          lemma: 'ôcênâs',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+      })
+    })
+
+    describe('animate intransitive verbs (VAI)', () => {
+      it('parses VAI verbs', () => {
+        expect(analyze('âhkamêyimow+V+AI+Ind+1Sg')).toEqual({
+          lemma: 'âhkamêyimow',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+awasêwêw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'awasêwêw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('IC+nahîw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'nahîw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+      })
+
+      it('parses VAI verbs with preverbs', () => {
+        expect(analyze('PV/ati+ohpîw+V+AI+Imp+Imm+2Sg')).toEqual({
+          lemma: 'ohpîw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+PV/ki+manîw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'manîw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+PV/wi+isîhcikêw+V+AI+Cnj+3Pl')).toEqual({
+          lemma: 'isîhcikêw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+      })
+
+      it('parses VAI verbs with multiple preverbs', () => {
+        expect(analyze('PV/e+PV/ki+PV/nihta+kâsôw+V+AI+Cnj+3Pl')).toEqual({
+          lemma: 'kâsôw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+PV/ki+PV/pimi+itinikêw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'itinikêw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+      })
+
+      it('parses VAI verbs with reduplication', () => {
+        expect(analyze('PV/e+RdplW+papâmipahtâw+V+AI+Cnj+3Pl')).toEqual({
+          lemma: 'papâmipahtâw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('RdplW+kaskihtâw+V+TI+Imp+Imm+2Sg')).toEqual({
+          lemma: 'kaskihtâw',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+      })
+    })
+
+    describe('inanimate intransitive verbs (VII)', () => {
+      it('parses VII verbs', () => {
+        expect(analyze('PV/e+ispahcâw+V+II+Cnj+4Sg')).toEqual({
+          lemma: 'ispahcâw',
+          wordType: 'V',
+          wordClass: 'VII'
+        })
+
+        expect(analyze('PV/kaa+ohpîw+V+II+Cnj+3Pl')).toEqual({
+          lemma: 'ohpîw',
+          wordType: 'V',
+          wordClass: 'VII'
+        })
+
+        expect(analyze('PV/e+PV/ati+wâpan+V+II+Cnj+4Sg')).toEqual({
+          lemma: 'wâpan',
+          wordType: 'V',
+          wordClass: 'VII'
+        })
+      })
+    })
+
+    describe('transitive animate verbs (VTA)', () => {
+      it('parses VTA verbs', () => {
+        expect(analyze('ahêw+V+TA+Ind+3Sg+1SgO')).toEqual({
+          lemma: 'ahêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+
+        expect(analyze('IC+PV/ako+ayâwêw+V+TA+Cnj+X+3PlO')).toEqual({
+          lemma: 'ayâwêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+
+        expect(analyze('PV/e+nôtinêw+V+TA+Cnj+3Sg+1SgO')).toEqual({
+          lemma: 'nôtinêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+      })
+
+      it('parses VTA verbs with preverbs', () => {
+        expect(analyze('PV/e+PV/ki+osâpamêw+V+TA+Cnj+2Sg+3PlO')).toEqual({
+          lemma: 'osâpamêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+
+        expect(analyze('PV/kaa+PV/ki+âsônamawêw+V+TA+Cnj+X+3PlO')).toEqual({
+          lemma: 'âsônamawêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+      })
+
+      it('parses VTA verbs with reduplication', () => {
+        expect(analyze('RdplW+kakwêcimêw+V+TA+Imp+Imm+2Pl+3PlO')).toEqual({
+          lemma: 'kakwêcimêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+
+        expect(analyze('RdplW+kâtêw+V+TA+Imp+Imm+2Sg+3PlO')).toEqual({
+          lemma: 'kâtêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+      })
+    })
+
+    describe('transitive inanimate verbs (VTI)', () => {
+      it('parses VTI verbs', () => {
+        expect(analyze('nahitôtam+V+TI+Ind+1Sg')).toEqual({
+          lemma: 'nahitôtam',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+
+        expect(analyze('PV/ati+ohpikihtâw+V+TI+Imp+Imm+2Sg')).toEqual({
+          lemma: 'ohpikihtâw',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+
+        expect(analyze('PV/e+itêyihtam+V+TI+Cnj+3Pl')).toEqual({
+          lemma: 'itêyihtam',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+      })
+
+      it('parses VTI verbs with preverbs', () => {
+        expect(analyze('PV/e+PV/ki+âpacihtâw+V+TI+Cnj+3Sg')).toEqual({
+          lemma: 'âpacihtâw',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+
+        expect(analyze('PV/kaa+PV/ki+wêhcihtâw+V+TI+Cnj+2Pl')).toEqual({
+          lemma: 'wêhcihtâw',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+      })
+
+      it('parses VTI verbs with reduplication', () => {
+        expect(analyze('PV/e+RdplW+tasîhtam+V+TI+Cnj+4Sg/Pl')).toEqual({
+          lemma: 'tasîhtam',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+
+        expect(analyze('RdplW+nitohtam+V+TI+Ind+1Sg')).toEqual({
+          lemma: 'nitohtam',
+          wordType: 'V',
+          wordClass: 'VTI'
+        })
+      })
+    })
+
+    describe('pronouns', () => {
+      it('parses pronouns', () => {
+        expect(analyze('awiyak+Pron+Indef+A+Sg')).toEqual({
+          lemma: 'awiyak',
+          wordType: 'Pron',
+          wordClass: 'Pron'
+        })
+
+        expect(analyze('ôhi+Pron+Dem+Prox+I+Pl')).toEqual({
+          lemma: 'ôhi',
+          wordType: 'Pron',
+          wordClass: 'Pron'
+        })
+      })
+    })
+
+    describe('edge cases', () => {
+      it('handles empty or invalid input', () => {
+        expect(analyze('')).toEqual({
+          lemma: null,
+          wordType: null,
+          wordClass: null
+        })
+
+        expect(analyze(null)).toEqual({
+          lemma: null,
+          wordType: null,
+          wordClass: null
+        })
+
+        expect(analyze(undefined)).toEqual({
+          lemma: null,
+          wordType: null,
+          wordClass: null
+        })
+      })
+
+      it('handles malformed analysis strings', () => {
+        expect(analyze('just-a-word')).toEqual({
+          lemma: 'just-a-word',
+          wordType: null,
+          wordClass: null
+        })
+      })
+
+      it('handles analysis with derivational morphology', () => {
+        expect(analyze('iskwêcâkan+N+A+Der/Dim+N+A+Obv')).toEqual({
+          lemma: 'iskwêcâkan',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+
+        expect(analyze('miyi+N+I+Der/Dim+N+I+Pl')).toEqual({
+          lemma: 'miyi',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+      })
+
+      it('handles dependent nouns (D tag)', () => {
+        expect(analyze('misit+N+I+D+Px1Sg+Sg')).toEqual({
+          lemma: 'misit',
+          wordType: 'N',
+          wordClass: 'NI'
+        })
+
+        expect(analyze('nîstâw+N+A+D+Px2Sg+Obv')).toEqual({
+          lemma: 'nîstâw',
+          wordType: 'N',
+          wordClass: 'NA'
+        })
+      })
+    })
+
+    describe('complex preverb combinations', () => {
+      it('handles multiple PV and reduplication together', () => {
+        expect(analyze('PV/e+PV/isi+RdplW+ispiciw+V+AI+Cnj+3Sg')).toEqual({
+          lemma: 'ispiciw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+
+        expect(analyze('PV/e+PV/ki+RdplW+natopayiw+V+AI+Cnj+3Pl')).toEqual({
+          lemma: 'natopayiw',
+          wordType: 'V',
+          wordClass: 'VAI'
+        })
+      })
+
+      it('handles IC with preverbs', () => {
+        expect(analyze('IC+PV/ako+ayâwêw+V+TA+Cnj+X+3PlO')).toEqual({
+          lemma: 'ayâwêw',
+          wordType: 'V',
+          wordClass: 'VTA'
+        })
+      })
+    })
+  })
+})
+

--- a/amplify/backend/function/indexRegionData/src/test/test-special-processing-crk.js
+++ b/amplify/backend/function/indexRegionData/src/test/test-special-processing-crk.js
@@ -27,19 +27,19 @@ describe('special-processing-crk', () => {
         expect(analyze('â+Ipc+Interj')).toEqual({
           lemma: 'â',
           wordType: 'Ipc',
-          wordClass: 'Ipc'
+          wordClass: 'IPC'
         })
 
         expect(analyze('âhâ+Ipc+Interj')).toEqual({
           lemma: 'âhâ',
           wordType: 'Ipc',
-          wordClass: 'Ipc'
+          wordClass: 'IPC'
         })
 
         expect(analyze('ahpô+Ipc')).toEqual({
           lemma: 'ahpô',
           wordType: 'Ipc',
-          wordClass: 'Ipc'
+          wordClass: 'IPC'
         })
       })
 
@@ -47,13 +47,13 @@ describe('special-processing-crk', () => {
         expect(analyze('anima+Ipc')).toEqual({
           lemma: 'anima',
           wordType: 'Ipc',
-          wordClass: 'Ipc'
+          wordClass: 'IPC'
         })
 
         expect(analyze('êkây+Ipc')).toEqual({
           lemma: 'êkây',
           wordType: 'Ipc',
-          wordClass: 'Ipc'
+          wordClass: 'IPC'
         })
       })
     })
@@ -333,13 +333,13 @@ describe('special-processing-crk', () => {
         expect(analyze('awiyak+Pron+Indef+A+Sg')).toEqual({
           lemma: 'awiyak',
           wordType: 'Pron',
-          wordClass: 'Pron'
+          wordClass: 'PRON'
         })
 
         expect(analyze('ôhi+Pron+Dem+Prox+I+Pl')).toEqual({
           lemma: 'ôhi',
           wordType: 'Pron',
-          wordClass: 'Pron'
+          wordClass: 'PRON'
         })
       })
     })

--- a/src/services/regionService.ts
+++ b/src/services/regionService.ts
@@ -136,10 +136,11 @@ export const updateRegion = async (regionId: string, updates: Partial<RegionData
     }
 
     // Create input for GraphQL using provided version (no pre-save fetch needed)
+    // After serialization, regionAnalysis is a string, so we cast appropriately
     const input: RegionUpdateInput = {
       id: regionId,
       _version: version,
-      ...(serializedUpdates as Omit<Partial<RegionData>, 'regionAnalysis'> & { regionAnalysis?: string | null }),
+      ...(serializedUpdates as unknown as Omit<Partial<RegionData>, 'regionAnalysis'> & { regionAnalysis?: string | null }),
       dateLastUpdated: new Date().toISOString(),
       userLastUpdated: username,
     };


### PR DESCRIPTION
Adds "special processing" case in the `indexRegion` Lambda so that language processing (indexing/analyzing) can be broken out. Also removes UofA (Sapir) Click-in-text API calls for analysis and just processes the provided analysis.