### PR TITLE
Add transcription export

### DIFF
--- a/src/components/forms/TranscriptionSettingsPage.tsx
+++ b/src/components/forms/TranscriptionSettingsPage.tsx
@@ -5,102 +5,15 @@ import { useRevokeInvite } from '../../hooks/useRevokeInvite';
 import { useDeleteTranscription } from '../../hooks/useDeleteTranscription';
 import * as inviteService from '../../services/inviteService';
 import { generateSignedUrl } from '../../services/transcriptionService';
-import type { InviteModel, TranscriptionModel, RegionModel } from '../../services/adt';
-
-const padNumber = (value: number, length: number): string => value.toString().padStart(length, '0');
-
-const formatTimecode = (seconds: number): string => {
-  const safeSeconds = Number.isFinite(seconds) ? Math.max(seconds, 0) : 0;
-  const totalMillis = Math.round(safeSeconds * 1000);
-  const hours = Math.floor(totalMillis / 3_600_000);
-  const minutes = Math.floor((totalMillis % 3_600_000) / 60_000);
-  const secs = Math.floor((totalMillis % 60_000) / 1_000);
-  const millis = totalMillis % 1_000;
-  return `${padNumber(hours, 2)}:${padNumber(minutes, 2)}:${padNumber(secs, 2)},${padNumber(millis, 3)}`;
-};
-
-const sanitizeLine = (value: string): string => value.replace(/\r?\n/g, ' ').replace(/\s+/g, ' ').trim();
-
-const buildExportContent = (
-  regions: RegionModel[],
-  options: { includeTranslation: boolean; includeTimestamps: boolean; includeRegionNumbers: boolean }
-): string => {
-  const preparedRegions = regions
-    .filter((region) => {
-      if (region.isNote) return false;
-      const hasPrimary = region.regionText && region.regionText.trim().length > 0;
-      const hasTranslation = options.includeTranslation && region.translation && region.translation.trim().length > 0;
-      return hasPrimary || hasTranslation;
-    })
-    .sort((a, b) => a.start - b.start);
-
-  if (preparedRegions.length === 0) {
-    throw new Error('There are no transcription regions with text to export.');
-  }
-
-  const segments = preparedRegions
-    .map((region, index) => {
-      const lines: string[] = [];
-
-      const primaryText = region.regionText?.trim();
-      if (primaryText) {
-        lines.push(sanitizeLine(primaryText));
-      }
-
-      if (options.includeTranslation) {
-        const translationText = region.translation?.trim();
-        if (translationText) {
-          lines.push(sanitizeLine(translationText));
-        }
-      }
-
-      if (lines.length === 0) {
-        return null;
-      }
-
-      const segmentParts: string[] = [];
-
-      if (options.includeRegionNumbers) {
-        segmentParts.push(`${index + 1}`);
-      }
-
-      if (options.includeTimestamps) {
-        const startTime = formatTimecode(region.start);
-        const endBoundary = region.end > region.start ? region.end : region.start + 0.001;
-        const endTime = formatTimecode(endBoundary);
-        segmentParts.push(`${startTime} --> ${endTime}`);
-      }
-
-      segmentParts.push(...lines);
-
-      return segmentParts.join('\n');
-    })
-    .filter((segment): segment is string => Boolean(segment));
-
-  if (segments.length === 0) {
-    throw new Error('There are no transcription regions with text to export.');
-  }
-
-  return segments.join('\n\n');
-};
-
-const deriveExportFilename = (transcription: TranscriptionModel): string => {
-  const fallbackBase = transcription.title?.trim() || transcription.id || 'transcription';
-  const sourceFilename = transcription.getSourceFilename();
-  if (!sourceFilename || sourceFilename === 'Unknown') {
-    return `${fallbackBase}.txt`;
-  }
-
-  const lastDotIndex = sourceFilename.lastIndexOf('.');
-  const baseName = lastDotIndex > 0 ? sourceFilename.slice(0, lastDotIndex) : sourceFilename;
-  return `${baseName}.txt`;
-};
+import type { InviteModel, TranscriptionModel } from '../../services/adt';
+import { useExportTranscription } from '../../hooks/useExportTranscription';
+import type { ExportRegion } from '../../use-cases/export-transcription';
 
 interface TranscriptionSettingsPageProps {
   transcription: TranscriptionModel;
   regionCount: number;
   issueCount: number;
-  regions: RegionModel[];
+  regions: ExportRegion[];
   onSave: (updates: { title?: string; comments?: string; isPrivate?: boolean; publicIssues?: boolean; lang?: string }) => void;
   onBack: () => void;
   onDelete?: () => void;
@@ -362,28 +275,22 @@ export const TranscriptionSettingsPage = ({
     }
   };
 
+  const exportTranscription = useExportTranscription();
+
   const handleExportTranscription = async () => {
     setExportError(null);
     setIsExporting(true);
 
     try {
-      const content = buildExportContent(regions, {
-        includeTranslation,
-        includeTimestamps,
-        includeRegionNumbers
+      await exportTranscription({
+        transcription,
+        regions,
+        options: {
+          includeTranslation,
+          includeTimestamps,
+          includeRegionNumbers,
+        },
       });
-      const filename = deriveExportFilename(transcription);
-      const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-
-      URL.revokeObjectURL(url);
       setShowExportDialog(false);
     } catch (error) {
       console.error('Transcription export failed:', error);

--- a/src/components/forms/TranscriptionSettingsPage.tsx
+++ b/src/components/forms/TranscriptionSettingsPage.tsx
@@ -5,12 +5,102 @@ import { useRevokeInvite } from '../../hooks/useRevokeInvite';
 import { useDeleteTranscription } from '../../hooks/useDeleteTranscription';
 import * as inviteService from '../../services/inviteService';
 import { generateSignedUrl } from '../../services/transcriptionService';
-import type { InviteModel, TranscriptionModel } from '../../services/adt';
+import type { InviteModel, TranscriptionModel, RegionModel } from '../../services/adt';
+
+const padNumber = (value: number, length: number): string => value.toString().padStart(length, '0');
+
+const formatTimecode = (seconds: number): string => {
+  const safeSeconds = Number.isFinite(seconds) ? Math.max(seconds, 0) : 0;
+  const totalMillis = Math.round(safeSeconds * 1000);
+  const hours = Math.floor(totalMillis / 3_600_000);
+  const minutes = Math.floor((totalMillis % 3_600_000) / 60_000);
+  const secs = Math.floor((totalMillis % 60_000) / 1_000);
+  const millis = totalMillis % 1_000;
+  return `${padNumber(hours, 2)}:${padNumber(minutes, 2)}:${padNumber(secs, 2)},${padNumber(millis, 3)}`;
+};
+
+const sanitizeLine = (value: string): string => value.replace(/\r?\n/g, ' ').replace(/\s+/g, ' ').trim();
+
+const buildExportContent = (
+  regions: RegionModel[],
+  options: { includeTranslation: boolean; includeTimestamps: boolean; includeRegionNumbers: boolean }
+): string => {
+  const preparedRegions = regions
+    .filter((region) => {
+      if (region.isNote) return false;
+      const hasPrimary = region.regionText && region.regionText.trim().length > 0;
+      const hasTranslation = options.includeTranslation && region.translation && region.translation.trim().length > 0;
+      return hasPrimary || hasTranslation;
+    })
+    .sort((a, b) => a.start - b.start);
+
+  if (preparedRegions.length === 0) {
+    throw new Error('There are no transcription regions with text to export.');
+  }
+
+  const segments = preparedRegions
+    .map((region, index) => {
+      const lines: string[] = [];
+
+      const primaryText = region.regionText?.trim();
+      if (primaryText) {
+        lines.push(sanitizeLine(primaryText));
+      }
+
+      if (options.includeTranslation) {
+        const translationText = region.translation?.trim();
+        if (translationText) {
+          lines.push(sanitizeLine(translationText));
+        }
+      }
+
+      if (lines.length === 0) {
+        return null;
+      }
+
+      const segmentParts: string[] = [];
+
+      if (options.includeRegionNumbers) {
+        segmentParts.push(`${index + 1}`);
+      }
+
+      if (options.includeTimestamps) {
+        const startTime = formatTimecode(region.start);
+        const endBoundary = region.end > region.start ? region.end : region.start + 0.001;
+        const endTime = formatTimecode(endBoundary);
+        segmentParts.push(`${startTime} --> ${endTime}`);
+      }
+
+      segmentParts.push(...lines);
+
+      return segmentParts.join('\n');
+    })
+    .filter((segment): segment is string => Boolean(segment));
+
+  if (segments.length === 0) {
+    throw new Error('There are no transcription regions with text to export.');
+  }
+
+  return segments.join('\n\n');
+};
+
+const deriveExportFilename = (transcription: TranscriptionModel): string => {
+  const fallbackBase = transcription.title?.trim() || transcription.id || 'transcription';
+  const sourceFilename = transcription.getSourceFilename();
+  if (!sourceFilename || sourceFilename === 'Unknown') {
+    return `${fallbackBase}.txt`;
+  }
+
+  const lastDotIndex = sourceFilename.lastIndexOf('.');
+  const baseName = lastDotIndex > 0 ? sourceFilename.slice(0, lastDotIndex) : sourceFilename;
+  return `${baseName}.txt`;
+};
 
 interface TranscriptionSettingsPageProps {
   transcription: TranscriptionModel;
   regionCount: number;
   issueCount: number;
+  regions: RegionModel[];
   onSave: (updates: { title?: string; comments?: string; isPrivate?: boolean; publicIssues?: boolean; lang?: string }) => void;
   onBack: () => void;
   onDelete?: () => void;
@@ -21,6 +111,7 @@ export const TranscriptionSettingsPage = ({
   transcription,
   regionCount,
   issueCount,
+  regions,
   onSave,
   onBack,
   onDelete,
@@ -58,7 +149,13 @@ export const TranscriptionSettingsPage = ({
   const [deleteError, setDeleteError] = useState<string | null>(null);
   
   // Download state
-  const [isDownloading, setIsDownloading] = useState(false);
+  const [isDownloadingSource, setIsDownloadingSource] = useState(false);
+  const [showExportDialog, setShowExportDialog] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [includeRegionNumbers, setIncludeRegionNumbers] = useState(true);
+  const [includeTimestamps, setIncludeTimestamps] = useState(true);
+  const [includeTranslation, setIncludeTranslation] = useState(true);
+  const [exportError, setExportError] = useState<string | null>(null);
   
   // Hooks
   const createInvite = useCreateInvite();
@@ -241,10 +338,10 @@ export const TranscriptionSettingsPage = ({
     }
   };
 
-  const handleDownload = async () => {
+  const handleDownloadSource = async () => {
     if (!transcription.source) return;
 
-    setIsDownloading(true);
+    setIsDownloadingSource(true);
     try {
       // Generate a fresh signed URL
       const signedUrl = await generateSignedUrl(transcription.source);
@@ -261,7 +358,38 @@ export const TranscriptionSettingsPage = ({
       console.error('Download failed:', error);
       // Could add error state/toast here if needed
     } finally {
-      setIsDownloading(false);
+      setIsDownloadingSource(false);
+    }
+  };
+
+  const handleExportTranscription = async () => {
+    setExportError(null);
+    setIsExporting(true);
+
+    try {
+      const content = buildExportContent(regions, {
+        includeTranslation,
+        includeTimestamps,
+        includeRegionNumbers
+      });
+      const filename = deriveExportFilename(transcription);
+      const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      URL.revokeObjectURL(url);
+      setShowExportDialog(false);
+    } catch (error) {
+      console.error('Transcription export failed:', error);
+      setExportError(error instanceof Error ? error.message : 'Failed to export transcription.');
+    } finally {
+      setIsExporting(false);
     }
   };
 
@@ -485,7 +613,20 @@ export const TranscriptionSettingsPage = ({
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-600">Total Regions</label>
-                    <p className="text-base text-gray-900 mt-1">{regionCount}</p>
+                    <div className="mt-1 flex items-center gap-2">
+                      <span className="text-base text-gray-900">{regionCount}</span>
+                      <button
+                        onClick={() => setShowExportDialog(true)}
+                        className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-purple-600 bg-purple-50 border border-purple-200 rounded hover:bg-purple-100 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-1 transition-colors"
+                        title="Export transcription"
+                      >
+                        <Download size={12} />
+                        Export transcription
+                      </button>
+                    </div>
+                    {exportError && (
+                      <p className="mt-2 text-xs text-red-600">{exportError}</p>
+                    )}
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-600">Total Issues</label>
@@ -494,15 +635,15 @@ export const TranscriptionSettingsPage = ({
                   <div>
                     <label className="block text-sm font-medium text-gray-600">Source File</label>
                     {transcription.source ? (
-                      <div className="flex items-center gap-2 mt-1">
+                      <div className="flex flex-wrap items-center gap-2 mt-1">
                         <span className="text-base text-gray-900 break-all flex-1">{transcription.getSourceFilename()}</span>
                         <button
-                          onClick={handleDownload}
-                          disabled={isDownloading}
+                          onClick={handleDownloadSource}
+                          disabled={isDownloadingSource}
                           className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-blue-600 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                           title="Download original file"
                         >
-                          {isDownloading ? (
+                          {isDownloadingSource ? (
                             <>
                               <Loader2 size={12} className="animate-spin" />
                               Downloading...
@@ -768,6 +909,130 @@ export const TranscriptionSettingsPage = ({
                   type="button"
                   onClick={handleDeleteCancel}
                   disabled={isDeleting}
+                  className="mt-3 inline-flex w-full justify-center rounded-lg bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showExportDialog && (
+        <div className="fixed inset-0 z-50">
+          <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+            <div className="fixed inset-0 bg-gray-800/60 backdrop-saturate-0 transition-opacity" onClick={() => setShowExportDialog(false)}></div>
+
+            <div className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-md sm:p-6">
+              <div className="sm:flex sm:items-start">
+                <div className="mt-3 text-center sm:mt-0 sm:text-left flex-1">
+                  <h3 className="text-base font-semibold leading-6 text-gray-900">
+                    Export transcription
+                  </h3>
+                  <p className="mt-2 text-sm text-gray-500">
+                    Choose the details to include in the exported transcript.
+                  </p>
+
+                  <div className="mt-4 space-y-3">
+                    <label className="flex items-center justify-between p-3 border border-gray-200 rounded-lg">
+                      <div>
+                        <span className="text-sm font-medium text-gray-900">Include region numbers</span>
+                        <p className="text-xs text-gray-500">Adds sequential numbering for each region.</p>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={includeRegionNumbers}
+                        onClick={() => setIncludeRegionNumbers(!includeRegionNumbers)}
+                        className={`
+                          relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2
+                          ${includeRegionNumbers ? 'bg-purple-600' : 'bg-gray-200'}
+                        `}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className={`
+                            pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out
+                            ${includeRegionNumbers ? 'translate-x-5' : 'translate-x-0'}
+                          `}
+                        />
+                      </button>
+                    </label>
+
+                    <label className="flex items-center justify-between p-3 border border-gray-200 rounded-lg">
+                      <div>
+                        <span className="text-sm font-medium text-gray-900">Include timestamps</span>
+                        <p className="text-xs text-gray-500">Adds region timing in HH:MM:SS,MS format.</p>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={includeTimestamps}
+                        onClick={() => setIncludeTimestamps(!includeTimestamps)}
+                        className={`
+                          relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2
+                          ${includeTimestamps ? 'bg-purple-600' : 'bg-gray-200'}
+                        `}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className={`
+                            pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out
+                            ${includeTimestamps ? 'translate-x-5' : 'translate-x-0'}
+                          `}
+                        />
+                      </button>
+                    </label>
+
+                    <label className="flex items-center justify-between p-3 border border-gray-200 rounded-lg">
+                      <div>
+                        <span className="text-sm font-medium text-gray-900">Include translation</span>
+                        <p className="text-xs text-gray-500">Adds translated text beneath each region when available.</p>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={includeTranslation}
+                        onClick={() => setIncludeTranslation(!includeTranslation)}
+                        className={`
+                          relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2
+                          ${includeTranslation ? 'bg-purple-600' : 'bg-gray-200'}
+                        `}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className={`
+                            pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out
+                            ${includeTranslation ? 'translate-x-5' : 'translate-x-0'}
+                          `}
+                        />
+                      </button>
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-6 sm:mt-5 sm:flex sm:flex-row-reverse">
+                <button
+                  type="button"
+                  onClick={handleExportTranscription}
+                  disabled={isExporting}
+                  className="inline-flex w-full justify-center rounded-lg bg-purple-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-purple-500 sm:ml-3 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isExporting ? (
+                    <>
+                      <Loader2 size={16} className="animate-spin mr-2" />
+                      Exporting...
+                    </>
+                  ) : (
+                    'Export'
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowExportDialog(false)}
+                  disabled={isExporting}
                   className="mt-3 inline-flex w-full justify-center rounded-lg bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Cancel

--- a/src/hooks/useExportTranscription.test.ts
+++ b/src/hooks/useExportTranscription.test.ts
@@ -1,0 +1,158 @@
+import { renderHook, act } from '@testing-library/react';
+import { useExportTranscription } from './useExportTranscription';
+import { ExportTranscriptionUseCase } from '../use-cases/export-transcription';
+
+jest.mock('../use-cases/export-transcription');
+
+const MockedExportTranscriptionUseCase = ExportTranscriptionUseCase as jest.MockedClass<typeof ExportTranscriptionUseCase>;
+
+const buildTranscription = () =>
+  ({
+    title: 'Example Transcription',
+    id: 'transcription-1',
+    getSourceFilename: () => 'example.mp3',
+  }) as unknown as import('../services/adt').TranscriptionModel;
+
+const buildRegion = () => ({
+  id: 'region-1',
+  start: 0,
+  end: 1,
+  isNote: false,
+  regionText: 'Hello',
+  translation: 'Bonjour',
+});
+
+describe('useExportTranscription', () => {
+  let createObjectURLMock: jest.Mock;
+  let revokeObjectURLMock: jest.Mock;
+  let appendChildSpy: jest.SpyInstance;
+  let removeChildSpy: jest.SpyInstance;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalAppendChild = document.body.appendChild;
+  const originalRemoveChild = document.body.removeChild;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    createObjectURLMock = jest.fn().mockReturnValue('blob:url');
+    revokeObjectURLMock = jest.fn();
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: createObjectURLMock,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: revokeObjectURLMock,
+    });
+
+    appendChildSpy = jest.spyOn(document.body, 'appendChild').mockImplementation((child) =>
+      originalAppendChild.call(document.body, child)
+    );
+    removeChildSpy = jest.spyOn(document.body, 'removeChild').mockImplementation((child) =>
+      originalRemoveChild.call(document.body, child)
+    );
+
+    MockedExportTranscriptionUseCase.mockImplementation(
+      () =>
+        ({
+          execute: () => ({
+            filename: 'example.txt',
+            content: 'Generated content',
+          }),
+        }) as unknown as ExportTranscriptionUseCase
+    );
+  });
+
+  afterEach(() => {
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      writable: true,
+      value: originalCreateObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      writable: true,
+      value: originalRevokeObjectURL,
+    });
+
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
+  });
+
+  it('creates and triggers a download using the export use case result', async () => {
+    const { result } = renderHook(() => useExportTranscription());
+    const initialAppendCalls = appendChildSpy.mock.calls.length;
+    const initialRemoveCalls = removeChildSpy.mock.calls.length;
+
+    await act(async () => {
+      await result.current({
+        transcription: buildTranscription(),
+        regions: [buildRegion()],
+        options: {
+          includeRegionNumbers: true,
+          includeTimestamps: true,
+          includeTranslation: true,
+        },
+      });
+    });
+
+    expect(MockedExportTranscriptionUseCase).toHaveBeenCalledWith({
+      transcription: expect.any(Object),
+      regions: expect.any(Array),
+      options: {
+        includeRegionNumbers: true,
+        includeTimestamps: true,
+        includeTranslation: true,
+      },
+    });
+
+    expect(createObjectURLMock).toHaveBeenCalledWith(expect.any(Blob));
+    expect(appendChildSpy.mock.calls.length).toBe(initialAppendCalls + 1);
+    expect(removeChildSpy.mock.calls.length).toBe(initialRemoveCalls + 1);
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:url');
+
+    const anchor = appendChildSpy.mock.calls[appendChildSpy.mock.calls.length - 1][0] as HTMLAnchorElement;
+    expect(anchor.download).toBe('example.txt');
+    expect(anchor.href).toBe('blob:url');
+  });
+
+  it('propagates errors from the use case', async () => {
+    const failure = new Error('failed to export');
+    MockedExportTranscriptionUseCase.mockImplementation(
+      () =>
+        ({
+          execute: () => {
+            throw failure;
+          },
+        }) as unknown as ExportTranscriptionUseCase
+    );
+
+    const { result } = renderHook(() => useExportTranscription());
+    const initialAppendCalls = appendChildSpy.mock.calls.length;
+    const initialRemoveCalls = removeChildSpy.mock.calls.length;
+
+    await expect(
+      act(async () => {
+        await result.current({
+          transcription: buildTranscription(),
+          regions: [buildRegion()],
+          options: {
+            includeRegionNumbers: false,
+            includeTimestamps: false,
+            includeTranslation: false,
+          },
+        });
+      })
+    ).rejects.toThrow(failure);
+
+    expect(createObjectURLMock).not.toHaveBeenCalled();
+    expect(appendChildSpy.mock.calls.length).toBe(initialAppendCalls);
+    expect(removeChildSpy.mock.calls.length).toBe(initialRemoveCalls);
+    expect(revokeObjectURLMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/hooks/useExportTranscription.ts
+++ b/src/hooks/useExportTranscription.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+import {
+  ExportTranscriptionUseCase,
+  type ExportTranscriptionOptions,
+  type ExportRegion
+} from '../use-cases/export-transcription';
+import type { TranscriptionModel } from '../services/adt';
+
+interface ExportTranscriptionInput {
+  transcription: TranscriptionModel;
+  regions: ExportRegion[];
+  options: ExportTranscriptionOptions;
+}
+
+export const useExportTranscription = () => {
+  return useCallback(async ({ transcription, regions, options }: ExportTranscriptionInput) => {
+    const useCase = new ExportTranscriptionUseCase({
+      transcription,
+      regions,
+      options,
+    });
+
+    const { filename, content } = useCase.execute();
+
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+
+    try {
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }, []);
+};
+

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -381,6 +381,7 @@ export const EditorPage = () => {
             transcription={new TranscriptionModel(transcription)}
             regionCount={regions.length}
             issueCount={issues.length}
+            regions={regions}
             onSave={handleSaveChanges}
             onBack={handleCloseSettings}
             onDelete={handleDeleteTranscription}

--- a/src/use-cases/export-transcription.test.ts
+++ b/src/use-cases/export-transcription.test.ts
@@ -1,0 +1,130 @@
+import { ExportTranscriptionUseCase, type ExportRegion } from './export-transcription';
+
+const buildTranscription = () =>
+  ({
+    title: 'My Transcription',
+    id: 'transcription-1',
+    getSourceFilename: () => 'original-file.mp3',
+  }) as unknown as import('../services/adt').TranscriptionModel;
+
+const buildRegion = (overrides: Partial<ExportRegion> = {}) =>
+  ({
+    id: 'region-1',
+    start: 0,
+    end: 2.5,
+    isNote: false,
+    regionText: 'Hello there',
+    translation: 'Bonjour',
+    ...overrides,
+  }) as import('../services/adt').RegionModel;
+
+describe('ExportTranscriptionUseCase', () => {
+  it('includes numbering, timestamps, and translation when options enabled', () => {
+    const useCase = new ExportTranscriptionUseCase({
+      transcription: buildTranscription(),
+      regions: [
+        buildRegion({ start: 0, end: 1.2, regionText: 'First region', translation: 'Première région' }),
+        buildRegion({ id: 'region-2', start: 2.5, end: 5, regionText: 'Second region', translation: 'Deuxième région' }),
+      ],
+      options: {
+        includeRegionNumbers: true,
+        includeTimestamps: true,
+        includeTranslation: true,
+      },
+    });
+
+    const { content, filename } = useCase.execute();
+
+    expect(filename).toBe('original-file.txt');
+    expect(content).toMatchInlineSnapshot(`
+"1
+00:00:00,000 --> 00:00:01,200
+First region
+Première région
+
+2
+00:00:02,500 --> 00:00:05,000
+Second region
+Deuxième région"
+`);
+  });
+
+  it('omits timestamps and translation when disabled', () => {
+    const useCase = new ExportTranscriptionUseCase({
+      transcription: buildTranscription(),
+      regions: [
+        buildRegion({ regionText: 'Only text', translation: 'should be excluded' }),
+      ],
+      options: {
+        includeRegionNumbers: true,
+        includeTimestamps: false,
+        includeTranslation: false,
+      },
+    });
+
+    const { content } = useCase.execute();
+
+    expect(content).toBe(`1
+Only text`);
+  });
+
+  it('derives filename from fallback when source filename is missing', () => {
+    const transcription = {
+      title: 'Sample Title',
+      id: 'fallback-id',
+      getSourceFilename: () => 'Unknown',
+    } as unknown as import('../services/adt').TranscriptionModel;
+
+    const useCase = new ExportTranscriptionUseCase({
+      transcription,
+      regions: [buildRegion()],
+      options: {
+        includeRegionNumbers: false,
+        includeTimestamps: false,
+        includeTranslation: false,
+      },
+    });
+
+    const { filename } = useCase.execute();
+    expect(filename).toBe('Sample Title.txt');
+  });
+
+  it('throws when all regions are notes', () => {
+    const useCase = new ExportTranscriptionUseCase({
+      transcription: buildTranscription(),
+      regions: [buildRegion({ isNote: true })],
+      options: {
+        includeRegionNumbers: true,
+        includeTimestamps: true,
+        includeTranslation: true,
+      },
+    });
+
+    expect(() => useCase.execute()).toThrow('There are no transcription regions with text to export.');
+  });
+
+  it('keeps regions without text when other options are enabled', () => {
+    const useCase = new ExportTranscriptionUseCase({
+      transcription: buildTranscription(),
+      regions: [
+        buildRegion({ regionText: '', translation: '', start: 1, end: 2 }),
+        buildRegion({ id: 'region-2', regionText: 'Content', translation: '', start: 3, end: 4 }),
+      ],
+      options: {
+        includeRegionNumbers: true,
+        includeTimestamps: true,
+        includeTranslation: true,
+      },
+    });
+
+    const { content } = useCase.execute();
+
+    expect(content).toBe(`1
+00:00:01,000 --> 00:00:02,000
+
+2
+00:00:03,000 --> 00:00:04,000
+Content`);
+  });
+});
+

--- a/src/use-cases/export-transcription.ts
+++ b/src/use-cases/export-transcription.ts
@@ -1,0 +1,122 @@
+import type { TranscriptionModel } from '../services/adt';
+
+export interface ExportTranscriptionOptions {
+  includeRegionNumbers: boolean;
+  includeTimestamps: boolean;
+  includeTranslation: boolean;
+}
+
+export interface ExportTranscriptionConfig {
+  transcription: TranscriptionModel;
+  regions: ExportRegion[];
+  options: ExportTranscriptionOptions;
+}
+
+export interface ExportTranscriptionResult {
+  filename: string;
+  content: string;
+}
+
+export interface ExportRegion {
+  id?: string;
+  start: number;
+  end: number;
+  isNote?: boolean;
+  regionText?: string;
+  translation?: string;
+}
+
+const padNumber = (value: number, length: number): string => value.toString().padStart(length, '0');
+
+const formatTimecode = (seconds: number): string => {
+  const safeSeconds = Number.isFinite(seconds) ? Math.max(seconds, 0) : 0;
+  const totalMillis = Math.round(safeSeconds * 1000);
+  const hours = Math.floor(totalMillis / 3_600_000);
+  const minutes = Math.floor((totalMillis % 3_600_000) / 60_000);
+  const secs = Math.floor((totalMillis % 60_000) / 1_000);
+  const millis = totalMillis % 1_000;
+  return `${padNumber(hours, 2)}:${padNumber(minutes, 2)}:${padNumber(secs, 2)},${padNumber(millis, 3)}`;
+};
+
+const sanitizeLine = (value: string): string => value.replace(/\r?\n/g, ' ').replace(/\s+/g, ' ').trim();
+
+export class ExportTranscriptionUseCase {
+  private readonly transcription: TranscriptionModel;
+  private readonly regions: ExportRegion[];
+  private readonly options: ExportTranscriptionOptions;
+
+  constructor(config: ExportTranscriptionConfig) {
+    this.transcription = config.transcription;
+    this.regions = config.regions;
+    this.options = config.options;
+  }
+
+  execute(): ExportTranscriptionResult {
+    if (!this.transcription) {
+      throw new Error('Transcription is required to export.');
+    }
+
+    const content = this.buildContent();
+    const filename = this.deriveFilename();
+
+    return { filename, content };
+  }
+
+  private buildContent(): string {
+    const segments = this.regions
+      .filter((region) => !(region.isNote ?? false))
+      .sort((a, b) => a.start - b.start)
+      .map((region, index) => {
+        const lines: string[] = [];
+
+        const primaryText = region.regionText?.trim();
+        if (primaryText) {
+          lines.push(sanitizeLine(primaryText));
+        }
+
+        if (this.options.includeTranslation) {
+          const translationText = region.translation?.trim();
+          if (translationText) {
+            lines.push(sanitizeLine(translationText));
+          }
+        }
+
+        const segmentParts: string[] = [];
+
+        if (this.options.includeRegionNumbers) {
+          segmentParts.push(`${index + 1}`);
+        }
+
+        if (this.options.includeTimestamps) {
+          const startTime = formatTimecode(region.start);
+          const endBoundary = region.end > region.start ? region.end : region.start + 0.001;
+          const endTime = formatTimecode(endBoundary);
+          segmentParts.push(`${startTime} --> ${endTime}`);
+        }
+
+        segmentParts.push(...lines);
+
+        return segmentParts.join('\n');
+      });
+
+    if (segments.length === 0) {
+      throw new Error('There are no transcription regions with text to export.');
+    }
+
+    return segments.join('\n\n');
+  }
+
+  private deriveFilename(): string {
+    const fallbackBase = this.transcription.title?.trim() || this.transcription.id || 'transcription';
+    const sourceFilename = this.transcription.getSourceFilename();
+
+    if (!sourceFilename || sourceFilename === 'Unknown') {
+      return `${fallbackBase}.txt`;
+    }
+
+    const lastDotIndex = sourceFilename.lastIndexOf('.');
+    const baseName = lastDotIndex > 0 ? sourceFilename.slice(0, lastDotIndex) : sourceFilename;
+    return `${baseName}.txt`;
+  }
+}
+

--- a/src/use-cases/export-transcription.ts
+++ b/src/use-cases/export-transcription.ts
@@ -1,4 +1,4 @@
-import type { TranscriptionModel } from '../services/adt';
+import type { RegionData, TranscriptionModel } from '../services/adt';
 
 export interface ExportTranscriptionOptions {
   includeRegionNumbers: boolean;
@@ -17,14 +17,7 @@ export interface ExportTranscriptionResult {
   content: string;
 }
 
-export interface ExportRegion {
-  id?: string;
-  start: number;
-  end: number;
-  isNote?: boolean;
-  regionText?: string;
-  translation?: string;
-}
+export type ExportRegion = Pick<RegionData, 'start' | 'end' | 'isNote' | 'regionText' | 'translation' | 'id'>;
 
 const padNumber = (value: number, length: number): string => value.toString().padStart(length, '0');
 


### PR DESCRIPTION
<img width="871" height="426" alt="Screenshot 2025-11-10 at 4 11 30 AM" src="https://github.com/user-attachments/assets/abdb227b-d1ef-4ef3-9f5b-f1815add83b8" />

Adds a button in the transcription settings to export the transcription data to a text file. By default the file is in SRT format (with a `.txt` extension), but every element that isn't the 'Original text' can be toggled on or off before exporting