### PR TITLE
Guard pending saves from nav

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
-import { Outlet, Link } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { Download, LogOut, HelpCircle, BookOpen } from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { useLoadMyInvites } from '../../hooks/useLoadMyInvites';
+import { GuardedLink } from './GuardedLink';
 import { signOut } from 'aws-amplify/auth';
 import { canPromptInstall, promptInstall, shouldShowInstall, isIosDevice } from '../../services/pwaInstallService';
 
@@ -76,13 +77,13 @@ export const AppLayout = () => {
             className="w-[40px] h-[40px] rounded-[3px] border border-white"
           />
           <nav className="hidden md:flex items-center gap-6 ml-5">
-            <Link
+            <GuardedLink
               to="/transcribe-list"
               className="text-white hover:text-white/80 transition-colors duration-200 text-base font-medium"
             >
               Transcriptions
-            </Link>
-            <Link
+            </GuardedLink>
+            <GuardedLink
               to="/invitations"
               className="text-white hover:text-white/80 transition-colors duration-200 text-base font-medium relative flex items-center"
             >
@@ -92,7 +93,7 @@ export const AppLayout = () => {
                   {pendingCount}
                 </span>
               )}
-            </Link>
+            </GuardedLink>
             <a
               href="https://docs.kiyanaw.net/"
               target="_blank"
@@ -148,14 +149,14 @@ export const AppLayout = () => {
                     </div>
                     
                     <div className="py-1">
-                      <Link
+                      <GuardedLink
                         to="/support"
                         onClick={() => setProfileDropdownOpen(false)}
                         className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 transition-colors duration-150 flex items-center gap-2"
                       >
                         <HelpCircle className="w-4 h-4" />
                         Support
-                      </Link>
+                      </GuardedLink>
                       {shouldShowInstall() && (
                         <button
                           onClick={async () => {
@@ -236,7 +237,7 @@ export const AppLayout = () => {
 
             {/* Navigation Links */}
             <div className="flex-1 py-4">
-              <Link
+              <GuardedLink
                 to="/transcribe-list"
                 onClick={() => setMobileMenuOpen(false)}
                 className="flex items-center px-6 py-3 text-gray-900 hover:bg-gray-50 active:bg-gray-100 transition-colors duration-150"
@@ -245,8 +246,8 @@ export const AppLayout = () => {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                 </svg>
                 <span className="font-medium">Transcriptions</span>
-              </Link>
-              <Link
+              </GuardedLink>
+              <GuardedLink
                 to="/invitations"
                 onClick={() => setMobileMenuOpen(false)}
                 className="flex items-center px-6 py-3 text-gray-900 hover:bg-gray-50 active:bg-gray-100 transition-colors duration-150 relative"
@@ -260,16 +261,16 @@ export const AppLayout = () => {
                     {pendingCount}
                   </span>
                 )}
-              </Link>
+              </GuardedLink>
 
-              <Link
+              <GuardedLink
                 to="/support"
                 onClick={() => setMobileMenuOpen(false)}
                 className="flex items-center px-6 py-3 text-gray-900 hover:bg-gray-50 active:bg-gray-100 transition-colors duration-150"
               >
                 <HelpCircle className="w-5 h-5 text-gray-600 mr-4" />
                 <span className="font-medium">Support</span>
-              </Link>
+              </GuardedLink>
               <a
                 href="https://docs.kiyanaw.net/"
                 target="_blank"

--- a/src/components/layout/GuardedLink.test.tsx
+++ b/src/components/layout/GuardedLink.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { GuardedLink } from './GuardedLink';
+import { regionSaveManager } from '../../services/regionSaveManager';
+
+// Mock the regionSaveManager
+jest.mock('../../services/regionSaveManager', () => ({
+  regionSaveManager: {
+    hasAnyPendingSaves: jest.fn(() => false),
+  },
+}));
+
+// Mock window.confirm
+const mockConfirm = jest.spyOn(window, 'confirm');
+
+describe('GuardedLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfirm.mockReturnValue(true);
+  });
+
+  afterAll(() => {
+    mockConfirm.mockRestore();
+  });
+
+  it('should navigate normally when no pending saves', () => {
+    (regionSaveManager.hasAnyPendingSaves as jest.Mock).mockReturnValue(false);
+
+    render(
+      <BrowserRouter>
+        <GuardedLink to="/test">Test Link</GuardedLink>
+      </BrowserRouter>
+    );
+
+    const link = screen.getByText('Test Link');
+    fireEvent.click(link);
+
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it('should show confirmation when pending saves exist', () => {
+    (regionSaveManager.hasAnyPendingSaves as jest.Mock).mockReturnValue(true);
+    mockConfirm.mockReturnValue(false); // User cancels
+
+    render(
+      <BrowserRouter>
+        <GuardedLink to="/test">Test Link</GuardedLink>
+      </BrowserRouter>
+    );
+
+    const link = screen.getByText('Test Link');
+    fireEvent.click(link);
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('unsaved changes')
+    );
+  });
+
+  it('should navigate when user confirms despite pending saves', () => {
+    (regionSaveManager.hasAnyPendingSaves as jest.Mock).mockReturnValue(true);
+    mockConfirm.mockReturnValue(true); // User confirms
+
+    render(
+      <BrowserRouter>
+        <GuardedLink to="/test">Test Link</GuardedLink>
+      </BrowserRouter>
+    );
+
+    const link = screen.getByText('Test Link');
+    fireEvent.click(link);
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.stringContaining('unsaved changes')
+    );
+    // Navigation would happen but we can't easily test that in this setup
+  });
+
+  it('should call provided onClick handler when no pending saves', () => {
+    (regionSaveManager.hasAnyPendingSaves as jest.Mock).mockReturnValue(false);
+    const onClick = jest.fn();
+
+    render(
+      <BrowserRouter>
+        <GuardedLink to="/test" onClick={onClick}>Test Link</GuardedLink>
+      </BrowserRouter>
+    );
+
+    const link = screen.getByText('Test Link');
+    fireEvent.click(link);
+
+    expect(onClick).toHaveBeenCalled();
+  });
+});
+

--- a/src/components/layout/GuardedLink.tsx
+++ b/src/components/layout/GuardedLink.tsx
@@ -1,0 +1,45 @@
+import { Link, useNavigate } from 'react-router-dom';
+import type { ComponentProps } from 'react';
+import { regionSaveManager } from '../../services/regionSaveManager';
+
+/**
+ * A Link component that checks for pending saves before navigating
+ * Shows a confirmation dialog if there are unsaved changes
+ */
+export const GuardedLink = ({ to, onClick, children, ...props }: ComponentProps<typeof Link>) => {
+  const navigate = useNavigate();
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    // Check if there are pending saves
+    if (regionSaveManager.hasAnyPendingSaves()) {
+      e.preventDefault();
+      
+      const shouldLeave = window.confirm(
+        'You have unsaved changes that are still being saved. If you leave now, you may lose your latest changes.\n\nAre you sure you want to leave?'
+      );
+      
+      if (shouldLeave) {
+        // User confirmed, proceed with navigation
+        if (typeof to === 'string') {
+          navigate(to);
+        } else if ('pathname' in to) {
+          navigate(to);
+        }
+      }
+      // If user cancelled, do nothing (stay on current page)
+      return;
+    }
+    
+    // No pending saves, call original onClick if provided
+    if (onClick) {
+      onClick(e);
+    }
+  };
+
+  return (
+    <Link to={to} onClick={handleClick} {...props}>
+      {children}
+    </Link>
+  );
+};
+

--- a/src/components/player/SaveIndicator.test.tsx
+++ b/src/components/player/SaveIndicator.test.tsx
@@ -10,6 +10,14 @@ describe('SaveIndicator', () => {
     expect(indicator.querySelector('svg')).toHaveClass('text-green-500');
   });
 
+  it('should render yellow clock for pending status', () => {
+    render(<SaveIndicator status="pending" />);
+    
+    const indicator = screen.getByTitle('Changes pending save...');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.querySelector('svg')).toHaveClass('text-yellow-500');
+  });
+
   it('should render spinning loader for saving status', () => {
     render(<SaveIndicator status="saving" />);
     

--- a/src/components/player/SaveIndicator.tsx
+++ b/src/components/player/SaveIndicator.tsx
@@ -1,7 +1,7 @@
-import { CircleCheckBig, Loader2, AlertCircle } from 'lucide-react';
+import { CircleCheckBig, Loader2, AlertCircle, Clock } from 'lucide-react';
 
 interface SaveIndicatorProps {
-  status: 'saved' | 'saving' | 'error';
+  status: 'saved' | 'saving' | 'pending' | 'error';
 }
 
 export const SaveIndicator = ({ status }: SaveIndicatorProps) => {
@@ -12,6 +12,17 @@ export const SaveIndicator = ({ status }: SaveIndicatorProps) => {
         title="All changes saved"
       >
         <CircleCheckBig size={14} className="text-green-500" />
+      </div>
+    );
+  }
+
+  if (status === 'pending') {
+    return (
+      <div 
+        className="flex items-center justify-center w-4 h-4"
+        title="Changes pending save..."
+      >
+        <Clock size={14} className="text-yellow-500" />
       </div>
     );
   }

--- a/src/hooks/useNavigationGuard.ts
+++ b/src/hooks/useNavigationGuard.ts
@@ -1,0 +1,59 @@
+import { useEffect, useCallback, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { regionSaveManager } from '../services/regionSaveManager';
+
+/**
+ * Hook to warn users when navigating away with pending changes
+ * Works with BrowserRouter by intercepting navigation and showing confirmation
+ */
+export const useNavigationGuard = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const currentPath = useRef(location.pathname);
+  const isNavigating = useRef(false);
+
+  // Update current path when location changes
+  useEffect(() => {
+    if (!isNavigating.current) {
+      currentPath.current = location.pathname;
+    }
+    isNavigating.current = false;
+  }, [location.pathname]);
+
+  // Handle browser navigation/close with beforeunload
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (regionSaveManager.hasAnyPendingSaves()) {
+        e.preventDefault();
+        e.returnValue = 'You have unsaved changes. Are you sure you want to leave?';
+        return e.returnValue;
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
+  // Intercept navigation attempts
+  const interceptNavigation = useCallback((targetPath: string) => {
+    if (regionSaveManager.hasAnyPendingSaves()) {
+      const shouldLeave = window.confirm(
+        'You have unsaved changes that are still being saved. If you leave now, you may lose your latest changes.\n\nAre you sure you want to leave?'
+      );
+      
+      if (shouldLeave) {
+        isNavigating.current = true;
+        navigate(targetPath);
+        return true;
+      }
+      return false;
+    }
+    return true;
+  }, [navigate]);
+
+  return { interceptNavigation };
+};
+

--- a/src/hooks/useTextEditors.integration.test.ts
+++ b/src/hooks/useTextEditors.integration.test.ts
@@ -133,7 +133,9 @@ describe('useTextEditors Integration Test', () => {
       isPendingEdit: jest.fn().mockReturnValue(false),
       startPendingEdit: jest.fn(),
       endPendingEdit: jest.fn(),
-      updatePendingEditActivity: jest.fn()
+      updatePendingEditActivity: jest.fn(),
+      // Add save status method
+      setSaveStatus: jest.fn()
     };
     
     (useEditorStore as unknown as jest.Mock).mockImplementation((selector) => {

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -7,6 +7,7 @@ import { useWavesurferEvents } from '../hooks/useWavesurferEvents';
 import { useSubscriptions } from '../hooks/useSubscriptions';
 import { useUpdateTranscription } from '../hooks/useUpdateTranscription';
 import { useAuthStore } from '../stores/useAuthStore';
+import { useNavigationGuard } from '../hooks/useNavigationGuard';
 
 import { useUpdateIssue } from '../hooks/useUpdateIssue';
 import { useDeleteIssue } from '../hooks/useDeleteIssue';
@@ -99,6 +100,7 @@ export const EditorPage = () => {
   
   useLoadTranscription(transcriptionId!);
   useSubscriptions(transcriptionId!);
+  useNavigationGuard(); // Warns on browser close/refresh if pending saves
   
   // Editor store selectors
   const transcription = useEditorStore((state) => state.transcription);

--- a/src/services/regionSaveManager.test.ts
+++ b/src/services/regionSaveManager.test.ts
@@ -21,6 +21,7 @@ jest.mock('./index', () => ({
       setRegionVersion: jest.fn(),
       setRegionText: jest.fn(),
       setRegionTranslation: jest.fn(),
+      setSaveStatus: jest.fn(),
     },
     spellCheckerService: {
       tokenize: jest.fn((text: string) => text.split(/\s+/).filter(Boolean)),

--- a/src/services/regionSaveManager.ts
+++ b/src/services/regionSaveManager.ts
@@ -37,7 +37,6 @@ class RegionSaveManagerImpl {
    * Queue a text change with automatic spell checking
    */
   queueTextChange(regionId: string, text: string): void {
-    console.debug(`💾 SAVE-MANAGER: Queuing text change for ${regionId}: "${text.substring(0, 50)}..."`);
     
     const queue = this.getOrCreateQueue(regionId);
     
@@ -47,20 +46,20 @@ class RegionSaveManagerImpl {
     queue.lastChangeTime = Date.now();
     queue.pendingEditField = 'regionText';
     
+    // Set save status to pending
+    services.storeService.setSaveStatus('pending');
+    
     // Cancel any existing spell check
     if (queue.spellCheckTimer) {
       Timeout.clear(queue.spellCheckTimer);
       queue.spellCheckPromise = null;
     }
     
-    // Start NEW spell check (debounced 500ms)
-    console.debug(`⏱️ SAVE-MANAGER: Starting spell check timer (500ms) for ${regionId}`);
     const spellCheckKey = `spell-check-${regionId}`;
     queue.spellCheckTimer = spellCheckKey;
     Timeout.set(
       spellCheckKey,
       async () => {
-        console.debug(`🔍 SAVE-MANAGER: Spell check firing for ${regionId}`);
         queue.spellCheckPromise = this.performSpellCheck(regionId, text);
         try {
           const analysis = await queue.spellCheckPromise;
@@ -74,8 +73,6 @@ class RegionSaveManagerImpl {
       500
     );
     
-    // Reset save timer (debounced 3000ms from last change)
-    console.debug(`⏱️ SAVE-MANAGER: Starting save timer (3000ms) for ${regionId}`);
     this.resetSaveTimer(regionId, 3000);
   }
   
@@ -92,6 +89,9 @@ class RegionSaveManagerImpl {
     queue.lastChangeTime = Date.now();
     queue.pendingEditField = 'translation';
     
+    // Set save status to pending
+    services.storeService.setSaveStatus('pending');
+    
     this.resetSaveTimer(regionId, 3000);
   }
   
@@ -107,6 +107,9 @@ class RegionSaveManagerImpl {
     queue.pendingChanges.end = end;
     queue.lastChangeSource = 'bounds';
     queue.lastChangeTime = Date.now();
+    
+    // Set save status to pending
+    services.storeService.setSaveStatus('pending');
     
     this.resetSaveTimer(regionId, 2500);
   }
@@ -206,6 +209,9 @@ class RegionSaveManagerImpl {
       hasSpellCheckPromise: !!queue.spellCheckPromise
     });
     
+    // Set status to saving
+    services.storeService.setSaveStatus('saving');
+    
     // Wait for spell check if pending
     await this.waitForSpellCheckCompletion(queue);
     
@@ -217,6 +223,11 @@ class RegionSaveManagerImpl {
     // Perform the save
     try {
       await this.saveRegionChanges(regionId, changes, pendingEditField);
+      
+      // Only set to 'saved' if no other pending saves exist
+      if (!this.hasAnyPendingSaves()) {
+        services.storeService.setSaveStatus('saved');
+      }
     } catch (error) {
       await this.handleSaveError(error, regionId, changes, pendingEditField);
     }
@@ -532,6 +543,13 @@ class RegionSaveManagerImpl {
    */
   hasPendingSaves(regionId: string): boolean {
     return this.queues.has(regionId);
+  }
+  
+  /**
+   * Check if there are any pending saves across all regions
+   */
+  hasAnyPendingSaves(): boolean {
+    return this.queues.size > 0;
   }
   
   // Helper methods

--- a/src/services/storeService.ts
+++ b/src/services/storeService.ts
@@ -20,7 +20,7 @@ export const storeService = {
     return useEditorStore.getState().transcription;
   },
 
-  setSaveStatus: (status: 'saved' | 'saving' | 'error'): void => {
+  setSaveStatus: (status: 'saved' | 'saving' | 'pending' | 'error'): void => {
     useEditorStore.getState().setSaveStatus(status);
   },
 

--- a/src/stores/useEditorStore.ts
+++ b/src/stores/useEditorStore.ts
@@ -30,7 +30,7 @@ interface EditorState {
   // Transcription state
   transcription: TranscriptionData | null;
   saved: boolean;
-  saveStatus: 'saved' | 'saving' | 'error';
+  saveStatus: 'saved' | 'saving' | 'pending' | 'error';
   peaks: number[] | null;
   wavesurferError: string | null;
   accessDenied: boolean;
@@ -85,7 +85,7 @@ interface EditorState {
   // Transcription actions
   setTranscription: (transcription: TranscriptionData) => void;
   setSaved: (saved: boolean) => void;
-  setSaveStatus: (status: 'saved' | 'saving' | 'error') => void;
+  setSaveStatus: (status: 'saved' | 'saving' | 'pending' | 'error') => void;
 
   // Region actions
   setSelectedRegion: (regionId: string | null) => void;


### PR DESCRIPTION
Right now if you are in the middle of a "pending save" and you navigate away from the transcription you will unapologetically lose your changes. 

This change updates the "saving icon" to show that there are pending saves and then warns the user if they attempt to leave while there is a pending save in the queue.

