### PR TITLE
Issue UI Improvements

### DIFF
--- a/src/components/issues/IssuesPanel.tsx
+++ b/src/components/issues/IssuesPanel.tsx
@@ -10,6 +10,7 @@ import { useNavigateIssueRegions } from '../../hooks/useNavigateIssueRegions';
 import { useIssueFlashIndicator } from '../../hooks/useIssueFlashIndicator';
 import { FLASH_CONFIG } from '../../services/flashIndicatorService';
 import { useSelectAndPlayRegion } from '../../hooks/useSelectAndPlayRegion';
+import { type IssueType } from '../../services/adt';
 
 // Suggestion Popover Component
 interface SuggestionPopoverProps {
@@ -82,7 +83,7 @@ const SuggestionPopover: React.FC<SuggestionPopoverProps> = ({
 interface Issue {
   id: string;
   text: string;
-  type: 'needs-help' | 'indexing' | 'new-word';
+  type: IssueType;
   owner: string; // UUID for permission checking
   ownerFriendly: string; // Friendly name for display
   regionId?: string;
@@ -201,7 +202,7 @@ const IssueListItem: React.FC<IssueListItemProps> = ({
                           key={type.value}
                           onClick={(e) => {
                             e.stopPropagation();
-                            handleTypeChange(issue.id, type.value as Issue['type']);
+                            handleTypeChange(issue.id, type.value as IssueType);
                           }}
                           className="inline-block py-0.5 px-2 rounded-xl text-xs font-medium uppercase cursor-pointer hover:opacity-90 transition-all duration-300 ease-out whitespace-nowrap shadow-lg"
                           style={{ 
@@ -404,8 +405,8 @@ interface IssuesPanelProps {
   onDeleteIssue: (issueId: string) => void;
   variant?: 'modal' | 'bottom-sheet';
   onJumpToRegion?: (regionId: string) => void;
-  enabledIssueTypes?: Set<'needs-help' | 'indexing' | 'new-word'>;
-  onToggleIssueType?: (type: 'needs-help' | 'indexing' | 'new-word') => void;
+  enabledIssueTypes?: Set<IssueType>;
+  onToggleIssueType?: (type: IssueType) => void;
   searchText?: string;
   onSearchChange?: (text: string) => void;
   onResetFilters?: () => void;
@@ -547,7 +548,7 @@ export const IssuesPanel = ({
     }
   };
 
-  const getIssueTypeInfo = (type: Issue['type']) => {
+  const getIssueTypeInfo = (type: IssueType) => {
     return issueTypes.find((t) => t.value === type) || issueTypes[0];
   };
 
@@ -632,11 +633,11 @@ export const IssuesPanel = ({
         <div className="px-4 py-2 bg-gray-100 border-b border-gray-200">
           <div className="flex gap-2 justify-start items-center">
             {issueTypes.map((type) => {
-              const isEnabled = enabledIssueTypes.has(type.value as 'needs-help' | 'indexing' | 'new-word');
+              const isEnabled = enabledIssueTypes.has(type.value as IssueType);
               return (
                 <button
                   key={type.value}
-                  onClick={() => onToggleIssueType(type.value as 'needs-help' | 'indexing' | 'new-word')}
+                  onClick={() => onToggleIssueType(type.value as IssueType)}
                   className={`px-1.5 py-0.5 text-[10px] font-medium uppercase rounded border transition-all hover:bg-gray-100 flex items-center gap-0.5 ${
                     isEnabled 
                       ? 'bg-white border-gray-300' 

--- a/src/components/issues/IssuesPanel.tsx
+++ b/src/components/issues/IssuesPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Check, Trash2, MessageSquare, AlertTriangle, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Check, Trash2, MessageSquare, AlertTriangle, ChevronLeft, ChevronRight, Filter } from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { useEditorStore } from '../../stores/useEditorStore';
 import { browserService } from '../../services/browserService';
@@ -404,6 +404,11 @@ interface IssuesPanelProps {
   onDeleteIssue: (issueId: string) => void;
   variant?: 'modal' | 'bottom-sheet';
   onJumpToRegion?: (regionId: string) => void;
+  enabledIssueTypes?: Set<'needs-help' | 'indexing' | 'new-word'>;
+  onToggleIssueType?: (type: 'needs-help' | 'indexing' | 'new-word') => void;
+  searchText?: string;
+  onSearchChange?: (text: string) => void;
+  onResetFilters?: () => void;
 }
 
 const issueTypes = [
@@ -420,6 +425,11 @@ export const IssuesPanel = ({
   onDeleteIssue,
   variant = 'modal',
   onJumpToRegion,
+  enabledIssueTypes,
+  onToggleIssueType,
+  searchText = '',
+  onSearchChange,
+  onResetFilters,
 }: IssuesPanelProps) => {
   const user = useAuthStore((state) => state.user);
   const selectAndPlayRegion = useSelectAndPlayRegion();
@@ -430,6 +440,7 @@ export const IssuesPanel = ({
   const setSelectedIssueId = useEditorStore((s) => s.setSelectedIssueId ?? (() => {}));
   const [dialogIssueId, setDialogIssueId] = useState<string | null>(selectedIssueId);
   const [isDialogOpen, setIsDialogOpen] = useState(!!selectedIssueId);
+  const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false);
 
   // Sync store selectedIssueId with local dialog state
   useEffect(() => {
@@ -585,6 +596,20 @@ export const IssuesPanel = ({
           })()}
         </div>
         <div className="flex items-center gap-2">
+          {/* Filter button - only show when no region selected */}
+          {!selectedRegionId && enabledIssueTypes && onToggleIssueType && (
+            <button
+              onClick={() => setIsFilterPanelOpen(!isFilterPanelOpen)}
+              className={`p-1.5 rounded border transition-all ${
+                enabledIssueTypes.size < 3
+                  ? 'border-ki-blue bg-ki-blue text-white hover:bg-blue-700'
+                  : 'border-gray-300 text-gray-700 hover:bg-gray-100'
+              }`}
+              title="Filter by issue type"
+            >
+              <Filter className="w-4 h-4" />
+            </button>
+          )}
           <div className="flex items-center gap-1" title="Navigate regions with unresolved issues">
             <button
               onClick={handleNavigateIssues('prev')}
@@ -601,6 +626,55 @@ export const IssuesPanel = ({
           </div>
         </div>
       </div>
+
+      {/* Collapsible Filter Panel */}
+      {!selectedRegionId && enabledIssueTypes && onToggleIssueType && isFilterPanelOpen && (
+        <div className="px-4 py-2 bg-gray-100 border-b border-gray-200">
+          <div className="flex gap-2 justify-start items-center">
+            {issueTypes.map((type) => {
+              const isEnabled = enabledIssueTypes.has(type.value as 'needs-help' | 'indexing' | 'new-word');
+              return (
+                <button
+                  key={type.value}
+                  onClick={() => onToggleIssueType(type.value as 'needs-help' | 'indexing' | 'new-word')}
+                  className={`px-1.5 py-0.5 text-[10px] font-medium uppercase rounded border transition-all hover:bg-gray-100 flex items-center gap-0.5 ${
+                    isEnabled 
+                      ? 'bg-white border-gray-300' 
+                      : 'bg-gray-100 border-gray-200'
+                  }`}
+                >
+                  <Check 
+                    className="w-2.5 h-2.5" 
+                    strokeWidth={3}
+                    style={{ color: isEnabled ? type.color : '#9ca3af' }} 
+                  />
+                  <span className={isEnabled ? '' : 'text-gray-400'} style={{ color: isEnabled ? type.color : undefined }}>
+                    {type.label}
+                  </span>
+                </button>
+              );
+            })}
+            {onSearchChange && (
+              <input
+                type="text"
+                value={searchText}
+                onChange={(e) => onSearchChange(e.target.value)}
+                placeholder="Search issues..."
+                className="px-2 py-0.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-ki-blue focus:border-ki-blue"
+                style={{ width: '150px' }}
+              />
+            )}
+            {onResetFilters && (enabledIssueTypes.size < 3 || searchText.trim()) && (
+              <button
+                onClick={onResetFilters}
+                className="px-2 py-0.5 text-xs font-medium rounded border border-gray-400 bg-white text-gray-700 hover:bg-gray-50 transition-all"
+              >
+                Reset
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto p-4">
         {filteredIssues.length === 0 ? (

--- a/src/components/regions/RegionList.tsx
+++ b/src/components/regions/RegionList.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react';
 import React from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 import { RegionItem } from './RegionItem';
 import type { RegionData } from '../../services/adt';
 import { useSelectAndPlayRegion } from '../../hooks/useSelectAndPlayRegion';
@@ -46,6 +47,34 @@ export const RegionList = React.memo(({
     }
   };
 
+  const handleNavigateUp = () => {
+    if (!loadedAndReady || regions.length === 0) return;
+    
+    if (!selectedRegionId) {
+      // No selection: go to last region
+      playRegion(regions[regions.length - 1].id);
+    } else {
+      // Go to previous region, wrap to last if at first
+      const currentIndex = regions.findIndex(r => r.id === selectedRegionId);
+      const prevIndex = currentIndex > 0 ? currentIndex - 1 : regions.length - 1;
+      playRegion(regions[prevIndex].id);
+    }
+  };
+
+  const handleNavigateDown = () => {
+    if (!loadedAndReady || regions.length === 0) return;
+    
+    if (!selectedRegionId) {
+      // No selection: go to first region
+      playRegion(regions[0].id);
+    } else {
+      // Go to next region, wrap to first if at last
+      const currentIndex = regions.findIndex(r => r.id === selectedRegionId);
+      const nextIndex = currentIndex < regions.length - 1 ? currentIndex + 1 : 0;
+      playRegion(regions[nextIndex].id);
+    }
+  };
+
   if (regions.length === 0) {
     return (
       <div className="h-full flex items-center justify-center bg-white border border-gray-300 rounded">
@@ -65,9 +94,26 @@ export const RegionList = React.memo(({
         </div>
       )}
       
-      <div className="py-3 px-4 bg-gray-100 border-b border-gray-300 flex-shrink-0">
+      <div className="py-3 px-4 bg-gray-100 border-b border-gray-300 flex-shrink-0 flex justify-between items-center">
         <h4 className="m-0 text-sm font-semibold text-gray-800 uppercase tracking-wide">Regions ({regions.length})</h4>
-
+        <div className="flex items-center gap-1">
+          <button
+            onClick={handleNavigateUp}
+            disabled={!loadedAndReady}
+            className="p-1.5 rounded border border-gray-300 hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            title="Previous region"
+          >
+            <ChevronUp className="w-4 h-4 text-gray-700" />
+          </button>
+          <button
+            onClick={handleNavigateDown}
+            disabled={!loadedAndReady}
+            className="p-1.5 rounded border border-gray-300 hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            title="Next region"
+          >
+            <ChevronDown className="w-4 h-4 text-gray-700" />
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-400 hover:scrollbar-thumb-gray-500 min-h-0 regions-scroll-mobile lg:regions-scroll-desktop">

--- a/src/pages/EditorPage.mapping.test.tsx
+++ b/src/pages/EditorPage.mapping.test.tsx
@@ -71,7 +71,7 @@ const mockStore = {
         {
           id: 'i1',
           text: 'ka-caciwihtat',
-          type: 'new-word',
+          type: 'new-word' as const,
           owner: 'owner-1',
           ownerFriendly: 'Owner',
           regionId: 'r1',

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -36,6 +36,14 @@ export const EditorPage = () => {
   // Mobile tab state
   const [mobileTab, setMobileTab] = useState<'editor' | 'regions' | 'issues'>('regions');
   
+  // Issue type filter state (all enabled by default)
+  const [enabledIssueTypes, setEnabledIssueTypes] = useState<Set<'needs-help' | 'indexing' | 'new-word'>>(
+    new Set(['needs-help', 'indexing', 'new-word'])
+  );
+  
+  // Issue search state
+  const [issueSearchText, setIssueSearchText] = useState('');
+  
   // Mobile swipe handling
   const handleTouchStart = useRef<{ x: number; y: number } | null>(null);
   const handleTouchMove = useRef<{ x: number; y: number } | null>(null);
@@ -128,6 +136,27 @@ export const EditorPage = () => {
   const handleSaveChanges = (updates: { title?: string; comments?: string; isPrivate?: boolean; publicIssues?: boolean; lang?: string }) => {
     updateTranscription(updates);
   };
+  
+  // Issue type filter handlers
+  const toggleIssueType = (type: 'needs-help' | 'indexing' | 'new-word') => {
+    setEnabledIssueTypes(prev => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        // Don't allow disabling all types
+        if (next.size > 1) {
+          next.delete(type);
+        }
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  };
+  
+  const resetFilters = () => {
+    setEnabledIssueTypes(new Set(['needs-help', 'indexing', 'new-word']));
+    setIssueSearchText('');
+  };
 
   const handleDeleteTranscription = () => {
     // Add a 4 second pause before navigating
@@ -140,6 +169,50 @@ export const EditorPage = () => {
   // Determine user permissions for this transcription
   const userCanEdit = canEdit(transcription, user);
   const isOwner = isAuthor(transcription, user);
+  
+  // Filter issues by enabled types and search text (only when no region selected)
+  const getFilteredIssues = () => {
+    if (!issues) return [];
+    
+    return issues
+      .filter(issue => {
+        // Filter by type
+        if (!enabledIssueTypes.has(issue.type as 'needs-help' | 'indexing' | 'new-word')) {
+          return false;
+        }
+        
+        // Filter by search text
+        if (issueSearchText.trim()) {
+          const searchLower = issueSearchText.toLowerCase();
+          return issue.text.toLowerCase().includes(searchLower);
+        }
+        
+        return true;
+      })
+      .map(issue => {
+        const linkStatus = selectedRegion?.id
+          ? issueLinkStatusesByRegion[selectedRegion.id]?.[issue.id]
+          : undefined;
+        const suggestions = selectedRegion?.id
+          ? issueSuggestionsByRegion[selectedRegion.id]?.[issue.id]
+          : undefined;
+
+        return {
+          id: issue.id,
+          text: issue.text,
+          type: issue.type as 'needs-help' | 'indexing' | 'new-word',
+          owner: issue.owner,
+          ownerFriendly: issue.ownerFriendly,
+          regionId: issue.regionId,
+          resolved: issue.resolved || false,
+          createdAt: issue.createdAt || new Date().toISOString(),
+          updatedAt: issue.updatedAt || new Date().toISOString(),
+          commentCount: issue.commentCount || 0,
+          linkStatus,
+          suggestions,
+        };
+      });
+  };
   
   // Issue management handlers
   const handleUpdateIssue = async (issueId: string, updates: { resolved?: boolean; text?: string; type?: string }) => {
@@ -233,33 +306,15 @@ export const EditorPage = () => {
               <>
                 <IssuesPanel
                   selectedRegionId={selectedRegion?.id}
-                  // TODO: why is this mapping happenning here and not our ADT?
-                  issues={(issues || []).map(issue => {
-                    const linkStatus = selectedRegion?.id
-                      ? issueLinkStatusesByRegion[selectedRegion.id]?.[issue.id]
-                      : undefined;
-                    const suggestions = selectedRegion?.id
-                      ? issueSuggestionsByRegion[selectedRegion.id]?.[issue.id]
-                      : undefined;
-
-                    return {
-                      id: issue.id,
-                      text: issue.text,
-                      type: issue.type as 'needs-help' | 'indexing' | 'new-word',
-                      owner: issue.owner, // Use actual owner UUID for permission checking
-                      ownerFriendly: issue.ownerFriendly,
-                      regionId: issue.regionId,
-                      resolved: issue.resolved || false,
-                      createdAt: issue.createdAt || new Date().toISOString(),
-                      updatedAt: issue.updatedAt || new Date().toISOString(),
-                      commentCount: issue.commentCount || 0,
-                      linkStatus,
-                      suggestions,
-                    };
-                  })}
+                  issues={getFilteredIssues()}
                   canEdit={userCanEdit}
                   onUpdateIssue={handleUpdateIssue}
                   onDeleteIssue={handleDeleteIssue}
+                  enabledIssueTypes={enabledIssueTypes}
+                  onToggleIssueType={toggleIssueType}
+                  searchText={issueSearchText}
+                  onSearchChange={setIssueSearchText}
+                  onResetFilters={resetFilters}
                 />
               </>
             )}
@@ -302,38 +357,20 @@ export const EditorPage = () => {
           )}
           
           {mobileTab === 'issues' && transcription && (
-            <div className="h-full overflow-hidden">
+            <div className="h-full overflow-hidden flex flex-col">
               <IssuesPanel
                 selectedRegionId={selectedRegion?.id}
-                // TODO: why is this mapping happenning here and not our ADT?
-                issues={(issues || []).map(issue => {
-                  const linkStatus = selectedRegion?.id
-                    ? issueLinkStatusesByRegion[selectedRegion.id]?.[issue.id]
-                    : undefined;
-                  const suggestions = selectedRegion?.id
-                    ? issueSuggestionsByRegion[selectedRegion.id]?.[issue.id]
-                    : undefined;
-
-                  return {
-                    id: issue.id,
-                    text: issue.text,
-                    type: issue.type as 'needs-help' | 'indexing' | 'new-word',
-                    owner: issue.owner, // Use actual owner UUID for permission checking
-                    ownerFriendly: issue.ownerFriendly,
-                    regionId: issue.regionId,
-                    resolved: issue.resolved || false,
-                    createdAt: issue.createdAt || new Date().toISOString(),
-                    updatedAt: issue.updatedAt || new Date().toISOString(),
-                    commentCount: issue.commentCount || 0,
-                    linkStatus,
-                    suggestions,
-                  };
-                })}
+                issues={getFilteredIssues()}
                 canEdit={userCanEdit}
                 onUpdateIssue={handleUpdateIssue}
                 onDeleteIssue={handleDeleteIssue}
                 variant="bottom-sheet"
                 onJumpToRegion={() => setMobileTab('regions')}
+                enabledIssueTypes={enabledIssueTypes}
+                onToggleIssueType={toggleIssueType}
+                searchText={issueSearchText}
+                onSearchChange={setIssueSearchText}
+                onResetFilters={resetFilters}
               />
             </div>
           )}

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -12,7 +12,7 @@ import { useNavigationGuard } from '../hooks/useNavigationGuard';
 import { useUpdateIssue } from '../hooks/useUpdateIssue';
 import { useDeleteIssue } from '../hooks/useDeleteIssue';
 import { canEdit, isAuthor } from '../lib/permissions';
-import { TranscriptionModel } from '../services/adt';
+import { TranscriptionModel, type IssueType } from '../services/adt';
 
 import { browserService } from '../services/browserService';
 import { wavesurferService } from '../services/wavesurferService';
@@ -37,7 +37,7 @@ export const EditorPage = () => {
   const [mobileTab, setMobileTab] = useState<'editor' | 'regions' | 'issues'>('regions');
   
   // Issue type filter state (all enabled by default)
-  const [enabledIssueTypes, setEnabledIssueTypes] = useState<Set<'needs-help' | 'indexing' | 'new-word'>>(
+  const [enabledIssueTypes, setEnabledIssueTypes] = useState<Set<IssueType>>(
     new Set(['needs-help', 'indexing', 'new-word'])
   );
   
@@ -138,7 +138,7 @@ export const EditorPage = () => {
   };
   
   // Issue type filter handlers
-  const toggleIssueType = (type: 'needs-help' | 'indexing' | 'new-word') => {
+  const toggleIssueType = (type: IssueType) => {
     setEnabledIssueTypes(prev => {
       const next = new Set(prev);
       if (next.has(type)) {
@@ -177,7 +177,7 @@ export const EditorPage = () => {
     return issues
       .filter(issue => {
         // Filter by type
-        if (!enabledIssueTypes.has(issue.type as 'needs-help' | 'indexing' | 'new-word')) {
+        if (!enabledIssueTypes.has(issue.type as IssueType)) {
           return false;
         }
         
@@ -200,7 +200,7 @@ export const EditorPage = () => {
         return {
           id: issue.id,
           text: issue.text,
-          type: issue.type as 'needs-help' | 'indexing' | 'new-word',
+          type: issue.type as IssueType,
           owner: issue.owner,
           ownerFriendly: issue.ownerFriendly,
           regionId: issue.regionId,
@@ -215,7 +215,7 @@ export const EditorPage = () => {
   };
   
   // Issue management handlers
-  const handleUpdateIssue = async (issueId: string, updates: { resolved?: boolean; text?: string; type?: string }) => {
+  const handleUpdateIssue = async (issueId: string, updates: { resolved?: boolean; text?: string; type?: IssueType }) => {
     try {
       await updateIssue({
         issueId,

--- a/src/services/adt.ts
+++ b/src/services/adt.ts
@@ -49,6 +49,9 @@ export interface IssueComment {
   text: string;
 }
 
+// Issue Types
+export type IssueType = 'needs-help' | 'indexing' | 'new-word';
+
 export interface IssueData {
   id: string;
   text: string;
@@ -56,7 +59,7 @@ export interface IssueData {
   ownerFriendly: string;
   index: number;
   resolved?: boolean;
-  type: string;
+  type: IssueType;
   dateLastUpdated: string;
   userLastUpdated: string;
   comments?: string; // AWSJSON - deprecated field, comments moving to Comment field

--- a/src/services/issueHighlightService.test.ts
+++ b/src/services/issueHighlightService.test.ts
@@ -11,7 +11,7 @@ describe('IssueHighlightService', () => {
           owner: 'user-1',
           ownerFriendly: 'user@example.com',
           index: 1,
-          type: 'needs-help',
+          type: 'needs-help' as const,
           regionId: 'region-1',
           transcriptionId: 'transcription-1',
           dateLastUpdated: '2023-01-01T00:00:00Z',
@@ -27,7 +27,7 @@ describe('IssueHighlightService', () => {
           owner: 'user-2',
           ownerFriendly: 'user2@example.com',
           index: 2,
-          type: 'new-word',
+          type: 'needs-help' as const,
           regionId: 'region-1',
           transcriptionId: 'transcription-1',
           dateLastUpdated: '2023-01-01T00:00:00Z',
@@ -42,8 +42,8 @@ describe('IssueHighlightService', () => {
       const result = issueHighlightService.convertIssuesToHighlights(issues);
 
       expect(result).toEqual([
-        { text: 'problematic word', id: 'issue-1', type: 'needs-help', commentCount: 0 },
-        { text: 'another issue', id: 'issue-2', type: 'new-word', commentCount: 0 }
+        { text: 'problematic word', id: 'issue-1', type: 'needs-help' as const, commentCount: 0 },
+        { text: 'another issue', id: 'issue-2', type: 'needs-help' as const, commentCount: 0 }
       ]);
     });
 
@@ -68,7 +68,7 @@ describe('IssueHighlightService', () => {
         {
           id: 'issue-with-comments',
           text: 'commented word',
-          type: 'new-word',
+          type: 'needs-help' as const,
           owner: 'user1',
           ownerFriendly: 'User One',
           resolved: false,
@@ -85,7 +85,7 @@ describe('IssueHighlightService', () => {
         {
           id: 'issue-no-comments',
           text: 'uncommented word',
-          type: 'indexing',
+          type: 'needs-help' as const,
           owner: 'user1',
           ownerFriendly: 'User One', 
           resolved: false,
@@ -104,8 +104,8 @@ describe('IssueHighlightService', () => {
       const result = issueHighlightService.convertIssuesToHighlights(issues);
 
       expect(result).toEqual([
-        { text: 'commented word', id: 'issue-with-comments', type: 'new-word', commentCount: 3 },
-        { text: 'uncommented word', id: 'issue-no-comments', type: 'indexing', commentCount: 0 }
+        { text: 'commented word', id: 'issue-with-comments', type: 'needs-help' as const, commentCount: 3 },
+        { text: 'uncommented word', id: 'issue-no-comments', type: 'needs-help' as const, commentCount: 0 }
       ]);
     });
   });

--- a/src/services/issueHighlightService.ts
+++ b/src/services/issueHighlightService.ts
@@ -1,5 +1,5 @@
-import type { IssueData } from './adt';
-import type { IssueHighlight, IssueType } from './textHighlightService';
+import type { IssueData, IssueType } from './adt';
+import type { IssueHighlight } from './textHighlightService';
 
 export interface IssueHighlightService {
   /**

--- a/src/services/issueMatchingService.test.ts
+++ b/src/services/issueMatchingService.test.ts
@@ -180,7 +180,7 @@ describe('IssueMatchingService', () => {
       id,
       text,
       resolved,
-      type: 'new-word',
+      type: 'new-word' as const,
       owner: 'user1',
       ownerFriendly: 'User One',
       regionId: 'region1',

--- a/src/services/issueService.test.ts
+++ b/src/services/issueService.test.ts
@@ -49,7 +49,7 @@ describe('issueService', () => {
       {
         id: 'issue-1',
         text: 'First issue',
-        type: 'new-word',
+        type: 'new-word' as const,
         owner: 'user-1',
         ownerFriendly: 'User One',
         regionId: 'region-1',
@@ -65,7 +65,7 @@ describe('issueService', () => {
       {
         id: 'issue-2',
         text: 'Second issue',
-        type: 'needs-help',
+        type: 'new-word' as const,
         owner: 'user-2',
         ownerFriendly: 'User Two',
         regionId: 'region-2',
@@ -171,7 +171,7 @@ describe('issueService', () => {
   describe('createIssueForRegion', () => {
     const issueData = {
       text: 'New test issue',
-      type: 'new-word',
+      type: 'new-word' as const,
       owner: 'user-123',
       ownerFriendly: 'Test User',
       regionId: 'region-456',
@@ -233,7 +233,7 @@ describe('issueService', () => {
     const updates = {
       text: 'Updated issue text',
       resolved: true,
-      type: 'needs-help',
+      type: 'new-word' as const,
       // Read-only fields that should be filtered out
       createdAt: '2023-01-01T00:00:00Z',
       updatedAt: '2023-01-02T00:00:00Z',
@@ -243,7 +243,7 @@ describe('issueService', () => {
     const mockUpdatedIssue: IssueData = {
       id: issueId,
       text: 'Updated issue text',
-      type: 'needs-help',
+      type: 'new-word' as const,
       owner: 'user-1',
       ownerFriendly: 'User One',
       regionId: 'region-1',
@@ -274,7 +274,7 @@ describe('issueService', () => {
             _version: version,
             text: 'Updated issue text',
             resolved: true,
-            type: 'needs-help',
+            type: 'new-word' as const,
             dateLastUpdated: expect.any(String),
             userLastUpdated: 'test-user'
             // createdAt, updatedAt, __typename should be filtered out

--- a/src/services/rteService.ts
+++ b/src/services/rteService.ts
@@ -3,7 +3,8 @@ import 'react-quill/dist/quill.snow.css';
 
 // Import quill-cursors for collaborative editing
 import QuillCursors from 'quill-cursors';
-import { textHighlightService, type IssueHighlight, type IssueType } from './textHighlightService';
+import { textHighlightService, type IssueHighlight } from './textHighlightService';
+import { type IssueType } from './adt';
 import { useEditorStore } from '../stores/useEditorStore';
 import { issueHighlightService } from './issueHighlightService';
 import { issueMatchingService } from './issueMatchingService';

--- a/src/services/textHighlightService.test.ts
+++ b/src/services/textHighlightService.test.ts
@@ -35,8 +35,8 @@ describe('TextHighlightService', () => {
     it('should highlight issues with red background', () => {
       const text = 'hello world test';
       const issues: IssueHighlight[] = [
-        { text: 'hello', id: 'issue-1', type: 'needs-help' },
-        { text: 'test', id: 'issue-2', type: 'indexing' }
+        { text: 'hello', id: 'issue-1', type: 'needs-help' as const },
+        { text: 'test', id: 'issue-2', type: 'indexing' as const }
       ];
       const options: HighlightOptions = { issues };
       
@@ -48,7 +48,7 @@ describe('TextHighlightService', () => {
     it('should highlight both known words and issues', () => {
       const text = 'hello world test';
       const knownWords = new Set(['world']);
-      const issues: IssueHighlight[] = [{ text: 'hello', id: 'issue-1', type: 'needs-help' }];
+      const issues: IssueHighlight[] = [{ text: 'hello', id: 'issue-1', type: 'needs-help' as const }];
       const options: HighlightOptions = { knownWords, issues };
       
       const result = textHighlightService.generateHTMLWithOptions(text, options);
@@ -59,7 +59,7 @@ describe('TextHighlightService', () => {
     it('should prioritize issues over known words for overlapping text', () => {
       const text = 'hello world';
       const knownWords = new Set(['hello']);
-      const issues: IssueHighlight[] = [{ text: 'hello', id: 'issue-1', type: 'new-word' }];
+      const issues: IssueHighlight[] = [{ text: 'hello', id: 'issue-1', type: 'new-word' as const }];
       const options: HighlightOptions = { knownWords, issues };
       
       const result = textHighlightService.generateHTMLWithOptions(text, options);
@@ -70,7 +70,7 @@ describe('TextHighlightService', () => {
     it('should handle case insensitive matching', () => {
       const text = 'Hello WORLD';
       const knownWords = new Set(['hello']);
-      const issues: IssueHighlight[] = [{ text: 'world', id: 'issue-1', type: 'indexing' }];
+      const issues: IssueHighlight[] = [{ text: 'world', id: 'issue-1', type: 'indexing' as const }];
       const options: HighlightOptions = { knownWords, issues };
       
       const result = textHighlightService.generateHTMLWithOptions(text, options);
@@ -90,7 +90,7 @@ describe('TextHighlightService', () => {
     it('should preserve text structure with punctuation', () => {
       const text = 'Hello, world! This is a test.';
       const knownWords = new Set(['hello']);
-      const issues: IssueHighlight[] = [{ text: 'test', id: 'issue-1', type: 'needs-help' }];
+      const issues: IssueHighlight[] = [{ text: 'test', id: 'issue-1', type: 'needs-help' as const }];
       const options: HighlightOptions = { knownWords, issues };
       
       const result = textHighlightService.generateHTMLWithOptions(text, options);
@@ -101,8 +101,8 @@ describe('TextHighlightService', () => {
     it('should include comment icons for issues with comments', () => {
       const text = 'hello commented word test';
       const issues: IssueHighlight[] = [
-        { text: 'commented', id: 'issue-1', type: 'new-word', commentCount: 2 },
-        { text: 'test', id: 'issue-2', type: 'needs-help', commentCount: 0 }
+        { text: 'commented', id: 'issue-1', type: 'new-word' as const, commentCount: 2 },
+        { text: 'test', id: 'issue-2', type: 'needs-help' as const, commentCount: 0 }
       ];
       const options: HighlightOptions = { issues };
       
@@ -114,7 +114,7 @@ describe('TextHighlightService', () => {
     it('should not include comment icons when commentCount is 0', () => {
       const text = 'hello uncommented word';
       const issues: IssueHighlight[] = [
-        { text: 'uncommented', id: 'issue-1', type: 'indexing', commentCount: 0 }
+        { text: 'uncommented', id: 'issue-1', type: 'indexing' as const, commentCount: 0 }
       ];
       const options: HighlightOptions = { issues };
       
@@ -126,7 +126,7 @@ describe('TextHighlightService', () => {
     it('should highlight longest token when issue text contains affix in parentheses', () => {
       const text = 'nitawāpēnākēw awa (ē-)tipinikāsowiht âhpinohk ohtāwiya - ohtāwīpana ēkwa.';
       const issues: IssueHighlight[] = [
-        { text: '(ē-)tipinikāsowiht', id: 'i1', type: 'new-word', commentCount: 0 },
+        { text: '(ē-)tipinikāsowiht', id: 'i1', type: 'new-word' as const, commentCount: 0 },
       ];
       const options: HighlightOptions = { issues };
 

--- a/src/services/textHighlightService.ts
+++ b/src/services/textHighlightService.ts
@@ -1,12 +1,11 @@
 import { REGION_TEXT_MATCH_PATTERN, REGION_TEXT_MATCH_PATTERN_GLOBAL } from '../constants/text-patterns';
+import { type IssueType } from './adt';
 
 export interface HighlightMatch {
   word: string;
   index: number;
   length: number;
 }
-
-export type IssueType = 'needs-help' | 'indexing' | 'new-word';
 
 export interface IssueHighlight {
   text: string;

--- a/src/use-cases/create-comment.test.ts
+++ b/src/use-cases/create-comment.test.ts
@@ -36,7 +36,7 @@ describe('CreateCommentUseCase', () => {
   const mockIssue: IssueData = {
     id: 'issue-789',
     text: 'Test issue',
-    type: 'new-word',
+    type: 'new-word' as const,
     owner: 'user-123',
     ownerFriendly: 'Test User',
     regionId: 'region-123',

--- a/src/use-cases/create-issue.test.ts
+++ b/src/use-cases/create-issue.test.ts
@@ -22,7 +22,7 @@ describe('CreateIssueUseCase', () => {
   const mockCreatedIssue: IssueData = {
     id: 'new-issue-id',
     text: 'Test issue text',
-    type: 'new-word',
+    type: 'new-word' as const,
     owner: 'user-123',
     ownerFriendly: 'Test User',
     regionId: 'region-456',
@@ -93,37 +93,37 @@ describe('CreateIssueUseCase', () => {
 
   describe('validate', () => {
     it('should throw error for missing text', () => {
-      const config = { text: '', type: 'new-word', owner: 'user-123', ownerFriendly: 'Test User', transcriptionId: 'trans-789' };
+      const config = { text: '', type: 'new-word' as const, owner: 'user-123', ownerFriendly: 'Test User', transcriptionId: 'trans-789' };
       const useCase = new CreateIssueUseCase(config);
       expect(() => useCase.validate()).toThrow('Issue text is required');
     });
 
     it('should throw error for whitespace-only text', () => {
-      const config = { text: '   ', type: 'new-word', owner: 'user-123', ownerFriendly: 'Test User', transcriptionId: 'trans-789' };
+      const config = { text: '   ', type: 'new-word' as const, owner: 'user-123', ownerFriendly: 'Test User', transcriptionId: 'trans-789' };
       const useCase = new CreateIssueUseCase(config);
       expect(() => useCase.validate()).toThrow('Issue text is required');
     });
 
     it('should throw error for missing type', () => {
-      const config = { text: 'Test issue', type: '', owner: 'user-123', ownerFriendly: 'Test User', transcriptionId: 'trans-789' };
+      const config = { text: 'Test issue', type: '' as any, owner: 'user-123', ownerFriendly: 'Test User', transcriptionId: 'trans-789' };
       const useCase = new CreateIssueUseCase(config);
       expect(() => useCase.validate()).toThrow('Issue type is required');
     });
 
     it('should throw error for missing owner', () => {
-      const config = { text: 'Test issue', type: 'new-word', owner: '', ownerFriendly: 'Test User', transcriptionId: 'trans-789' };
+      const config = { text: 'Test issue', type: 'new-word' as const, owner: '', ownerFriendly: 'Test User', transcriptionId: 'trans-789' };
       const useCase = new CreateIssueUseCase(config);
       expect(() => useCase.validate()).toThrow('Issue owner is required');
     });
 
     it('should throw error for missing ownerFriendly', () => {
-      const config = { text: 'Test issue', type: 'new-word', owner: 'user-123', ownerFriendly: '', transcriptionId: 'trans-789' };
+      const config = { text: 'Test issue', type: 'new-word' as const, owner: 'user-123', ownerFriendly: '', transcriptionId: 'trans-789' };
       const useCase = new CreateIssueUseCase(config);
       expect(() => useCase.validate()).toThrow('Issue owner friendly name is required');
     });
 
     it('should throw error for missing transcriptionId', () => {
-      const config = { text: 'Test issue', type: 'new-word', owner: 'user-123', ownerFriendly: 'Test User', transcriptionId: '' };
+      const config = { text: 'Test issue', type: 'new-word' as const, owner: 'user-123', ownerFriendly: 'Test User', transcriptionId: '' };
       const useCase = new CreateIssueUseCase(config);
       expect(() => useCase.validate()).toThrow('Transcription ID is required');
     });
@@ -131,7 +131,7 @@ describe('CreateIssueUseCase', () => {
     it('should pass validation for valid input', () => {
       const config = { 
         text: 'Test issue', 
-        type: 'new-word', 
+        type: 'new-word' as const, 
         owner: 'user-123', 
         ownerFriendly: 'Test User',
         transcriptionId: 'trans-789' 
@@ -143,7 +143,7 @@ describe('CreateIssueUseCase', () => {
     it('should pass validation with optional regionId', () => {
       const config = { 
         text: 'Test issue', 
-        type: 'new-word', 
+        type: 'new-word' as const, 
         owner: 'user-123', 
         ownerFriendly: 'Test User',
         regionId: 'region-456',
@@ -157,7 +157,7 @@ describe('CreateIssueUseCase', () => {
   describe('execute', () => {
     const validConfig: CreateIssueConfig = {
       text: 'Test issue text',
-      type: 'new-word',
+      type: 'new-word' as const,
       owner: 'user-123',
       ownerFriendly: 'Test User',
       regionId: 'region-456',
@@ -173,7 +173,7 @@ describe('CreateIssueUseCase', () => {
       // Verify service call
       expect(mockCreateIssueForRegion).toHaveBeenCalledWith({
         text: 'Test issue text',
-        type: 'new-word',
+        type: 'new-word' as const,
         owner: 'user-123',
         ownerFriendly: 'Test User',
         regionId: 'region-456',
@@ -200,7 +200,7 @@ describe('CreateIssueUseCase', () => {
 
       expect(mockCreateIssueForRegion).toHaveBeenCalledWith({
         text: 'Test issue text',
-        type: 'new-word',
+        type: 'new-word' as const,
         owner: 'user-123',
         ownerFriendly: 'Test User',
         regionId: '',
@@ -220,7 +220,7 @@ describe('CreateIssueUseCase', () => {
 
       expect(mockCreateIssueForRegion).toHaveBeenCalledWith({
         text: 'Test issue text',
-        type: 'new-word',
+        type: 'new-word' as const,
         owner: 'user-123',
         ownerFriendly: 'Test User',
         regionId: 'region-456',
@@ -238,7 +238,7 @@ describe('CreateIssueUseCase', () => {
 
       expect(mockCreateIssueForRegion).toHaveBeenCalledWith({
         text: 'ē-mânokâkēcik issue',
-        type: 'new-word',
+        type: 'new-word' as const,
         owner: 'user-123',
         ownerFriendly: 'Test User',
         regionId: 'region-456',
@@ -249,8 +249,8 @@ describe('CreateIssueUseCase', () => {
     });
 
     it('should handle different issue types', async () => {
-      const needsHelpConfig = { ...validConfig, type: 'needs-help' };
-      const needsHelpIssue = { ...mockCreatedIssue, type: 'needs-help' };
+      const needsHelpConfig = { ...validConfig, type: 'needs-help' as const };
+      const needsHelpIssue = { ...mockCreatedIssue, type: 'needs-help' as const };
       mockCreateIssueForRegion.mockResolvedValue(needsHelpIssue);
 
       const useCase = new CreateIssueUseCase(needsHelpConfig);
@@ -258,7 +258,7 @@ describe('CreateIssueUseCase', () => {
 
       expect(mockCreateIssueForRegion).toHaveBeenCalledWith({
         text: 'Test issue text',
-        type: 'needs-help',
+        type: 'needs-help' as const,
         owner: 'user-123',
         ownerFriendly: 'Test User',
         regionId: 'region-456',
@@ -304,7 +304,7 @@ describe('CreateIssueUseCase', () => {
 
       expect(mockCreateIssueForRegion).toHaveBeenCalledWith({
         text: longText,
-        type: 'new-word',
+        type: 'new-word' as const,
         owner: 'user-123',
         ownerFriendly: 'Test User',
         regionId: 'region-456',
@@ -324,7 +324,7 @@ describe('CreateIssueUseCase', () => {
 
       expect(mockCreateIssueForRegion).toHaveBeenCalledWith({
         text: 'Text with \n newlines \t and tabs',
-        type: 'new-word',
+        type: 'new-word' as const,
         owner: 'user-123',
         ownerFriendly: 'Test User',
         regionId: 'region-456',
@@ -344,7 +344,7 @@ describe('CreateIssueUseCase', () => {
 
       expect(mockCreateIssueForRegion).toHaveBeenCalledWith({
         text: 'Test issue text',
-        type: 'new-word',
+        type: 'new-word' as const,
         owner: 'user-123',
         ownerFriendly: 'Test User',
         regionId: '',

--- a/src/use-cases/create-issue.ts
+++ b/src/use-cases/create-issue.ts
@@ -4,11 +4,11 @@ import { rteService } from '../services/rteService';
 import { currentUser } from '../services/userService';
 import { services } from '../services';
 import { UpdateTranscriptionUseCase } from './update-transcription';
-import type { IssueData } from '../services/adt';
+import type { IssueData, IssueType } from '../services/adt';
 
 export interface CreateIssueConfig {
   text: string;
-  type: string;
+  type: IssueType;
   owner: string;
   ownerFriendly: string;
   regionId?: string;

--- a/src/use-cases/delete-comment.test.ts
+++ b/src/use-cases/delete-comment.test.ts
@@ -51,7 +51,7 @@ describe('DeleteCommentUseCase', () => {
   const mockIssue: IssueData = {
     id: 'issue-789',
     text: 'Test issue',
-    type: 'new-word',
+    type: 'new-word' as const,
     owner: 'user-123',
     ownerFriendly: 'Test User',
     regionId: 'region-123',

--- a/src/use-cases/delete-issue.test.ts
+++ b/src/use-cases/delete-issue.test.ts
@@ -19,7 +19,7 @@ describe('DeleteIssueUseCase', () => {
   const mockIssue: IssueData = {
     id: 'issue-123',
     text: 'Test issue text',
-    type: 'new-word',
+    type: 'new-word' as const,
     owner: 'user-123',
     ownerFriendly: 'Test User',
     regionId: 'region-456',

--- a/src/use-cases/subscribe-to-comment-changes.test.ts
+++ b/src/use-cases/subscribe-to-comment-changes.test.ts
@@ -68,7 +68,7 @@ describe('SubscribeToCommentChangesUseCase', () => {
     ownerFriendly: 'Test User',
     index: 1,
     resolved: false,
-    type: 'needs-help',
+    type: 'needs-help' as const,
     regionId: 'region-456',
     transcriptionId: 'transcription-789',
     dateLastUpdated: '2023-01-01T00:00:00Z',

--- a/src/use-cases/subscribe-to-issue-changes.test.ts
+++ b/src/use-cases/subscribe-to-issue-changes.test.ts
@@ -6,7 +6,7 @@ import type { RegionData } from '../types/shared';
 const mockIssue: IssueData = {
   id: 'issue-1',
   text: 'Test issue',
-  type: 'spelling',
+  type: 'needs-help' as const,
   owner: 'user-123',
   ownerFriendly: 'Test User',
   resolved: false,
@@ -212,7 +212,7 @@ describe('SubscribeToIssueChangesUseCase', () => {
 
         expect(mockServices.storeService.updateIssue).toHaveBeenCalledWith('issue-1', {
           text: 'Updated text',
-          type: 'spelling',
+          type: 'needs-help' as const,
           resolved: true,
           commentCount: 5,
           ownerFriendly: 'Test User',

--- a/src/use-cases/update-issue-text.test.ts
+++ b/src/use-cases/update-issue-text.test.ts
@@ -30,7 +30,7 @@ describe('UpdateIssueTextUseCase', () => {
   const mockIssue: IssueData = {
     id: 'issue-123',
     text: 'Original issue text',
-    type: 'new-word',
+    type: 'new-word' as const,
     owner: 'user-123',
     ownerFriendly: 'Test User',
     regionId: 'region-456',

--- a/src/use-cases/update-issue.test.ts
+++ b/src/use-cases/update-issue.test.ts
@@ -21,7 +21,7 @@ describe('UpdateIssueUseCase', () => {
   const mockIssue: IssueData = {
     id: 'issue-123',
     text: 'Original issue text',
-    type: 'new-word',
+    type: 'new-word' as const,
     owner: 'user-123',
     ownerFriendly: 'Test User',
     regionId: 'region-456',


### PR DESCRIPTION
PR adds a couple enhancements to the UI for usability:

 * ability to toggle on/off which issues types to view
 * ability to search issues by text
 * adds next/previous buttons to issue list, "previous" at Region 1 will navigate to last region

<img width="2970" height="874" alt="screenshot-2025-11-21-14 06 11@2x" src="https://github.com/user-attachments/assets/209254ab-3738-453e-9189-37ecf1a56891" />

<img width="1104" height="756" alt="screenshot-2025-11-21-14 06 18@2x" src="https://github.com/user-attachments/assets/14510a88-2f0d-4944-b49f-b8ea5caae6e6" />
