### PR TITLE
Another stab at token expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,30 @@ playwright-report/
 test-results/
 .env
 debug-*.png
+
+# Claude Flow generated files
+.claude/settings.local.json
+.mcp.json
+claude-flow.config.json
+.swarm/
+.hive-mind/
+.claude-flow/
+memory/
+coordination/
+memory/claude-flow-data.json
+memory/sessions/*
+!memory/sessions/README.md
+memory/agents/*
+!memory/agents/README.md
+coordination/memory_bank/*
+coordination/subtasks/*
+coordination/orchestration/*
+*.db
+*.db-journal
+*.db-wal
+*.sqlite
+*.sqlite-journal
+*.sqlite-wal
+claude-flow
+# Removed Windows wrapper files per user request
+hive-mind-prompt-*.txt

--- a/src/components/player/ExpiredCredentialsDialog.tsx
+++ b/src/components/player/ExpiredCredentialsDialog.tsx
@@ -4,11 +4,13 @@ import { getSignedUrlExpirationTime } from '../../services/transcriptionService'
 
 interface ExpiredCredentialsDialogProps {
   isOpen: boolean;
+  isRefreshing?: boolean;
+  isSaving?: boolean;
   onRefresh: () => void;
   onClose: () => void;
 }
 
-export const ExpiredCredentialsDialog = ({ isOpen, onRefresh, onClose }: ExpiredCredentialsDialogProps) => {
+export const ExpiredCredentialsDialog = ({ isOpen, isRefreshing = false, isSaving = false, onRefresh, onClose }: ExpiredCredentialsDialogProps) => {
   const [minutesRemaining, setMinutesRemaining] = useState<number | null>(null);
 
   useEffect(() => {
@@ -51,11 +53,18 @@ export const ExpiredCredentialsDialog = ({ isOpen, onRefresh, onClose }: Expired
       ? `${minutesRemaining} minute${minutesRemaining !== 1 ? 's' : ''} until media access credentials expire. Refresh now.`
       : `${minutesRemaining} minute${minutesRemaining !== 1 ? 's' : ''} until media access credentials expire.`;
 
+  const handleBackdropClick = () => {
+    // Only allow closing via backdrop if not expired and not in a loading state
+    if (!isExpired && !isRefreshing && !isSaving) {
+      onClose();
+    }
+  };
+
   return (
-    <div 
+    <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
-      onClick={onClose}
+      onClick={handleBackdropClick}
     >
       <div 
         className="bg-white rounded-lg shadow-xl max-w-md w-full p-6"
@@ -73,21 +82,25 @@ export const ExpiredCredentialsDialog = ({ isOpen, onRefresh, onClose }: Expired
         </p>
         
         <p className="text-sm text-gray-600 mb-6">
-          Temporary credentials are used to access your media files stored within the platform. Once credentials expire, please refresh the page to obtain fresh credentials.
+          Temporary credentials are used to access your media files stored within the platform. Once credentials expire, click Refresh to obtain fresh credentials.
         </p>
         
         <div className="flex gap-3">
-          <button
-            onClick={onClose}
-            className="flex-1 bg-gray-200 text-gray-700 px-4 py-2 rounded hover:bg-gray-300 transition-colors font-medium"
-          >
-            Cancel
-          </button>
+          {!isExpired && (
+            <button
+              onClick={onClose}
+              disabled={isRefreshing || isSaving}
+              className="flex-1 bg-gray-200 text-gray-700 px-4 py-2 rounded hover:bg-gray-300 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+          )}
           <button
             onClick={onRefresh}
-            className="flex-1 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors font-medium"
+            disabled={isRefreshing || isSaving}
+            className="flex-1 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Refresh Page
+            {isSaving ? 'Saving...' : isRefreshing ? 'Refreshing...' : 'Refresh'}
           </button>
         </div>
       </div>

--- a/src/components/player/WaveformPlayer.tsx
+++ b/src/components/player/WaveformPlayer.tsx
@@ -13,6 +13,8 @@ import { browserService } from '../../services/browserService';
 import { formatTime } from '../../utils/timeFormat';
 import { CredentialTimer } from './CredentialTimer';
 import { ExpiredCredentialsDialog } from './ExpiredCredentialsDialog';
+import { useRefreshMediaCredentials } from '../../hooks/useRefreshMediaCredentials';
+import { useHasPendingSaves } from '../../hooks/useHasPendingSaves';
 
 interface Region {
   id: string;
@@ -72,6 +74,10 @@ export const WaveformPlayer = ({
   const saveStatus = useEditorStore((state) => state.saveStatus);
   const showExpiredCredentialsDialog = useEditorStore((state) => state.showExpiredCredentialsDialog);
   const setShowExpiredCredentialsDialog = useEditorStore((state) => state.setShowExpiredCredentialsDialog);
+  const peaks = useEditorStore((state) => state.peaks);
+
+  const { refreshCredentials, isRefreshing } = useRefreshMediaCredentials();
+  const hasPendingSaves = useHasPendingSaves(showExpiredCredentialsDialog);
   
   const play = usePlay()
   const pause = usePause()
@@ -641,9 +647,17 @@ export const WaveformPlayer = ({
       {/* Expired Credentials Dialog */}
       <ExpiredCredentialsDialog
         isOpen={showExpiredCredentialsDialog}
-        onRefresh={() => {
-          setShowExpiredCredentialsDialog(false);
-          window.location.reload();
+        isRefreshing={isRefreshing}
+        isSaving={hasPendingSaves}
+        onRefresh={async () => {
+          try {
+            await refreshCredentials(source, peaks);
+            setShowExpiredCredentialsDialog(false);
+          } catch (error) {
+            console.error('Failed to refresh credentials:', error);
+            // On error, fall back to page reload
+            window.location.reload();
+          }
         }}
         onClose={() => setShowExpiredCredentialsDialog(false)}
       />

--- a/src/hooks/useHasPendingSaves.ts
+++ b/src/hooks/useHasPendingSaves.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+import { regionSaveManager } from '../services/regionSaveManager';
+
+/**
+ * Hook to track if there are any pending region saves.
+ * Polls the regionSaveManager at regular intervals.
+ *
+ * @param active - Whether to actively poll (default: true)
+ * @returns boolean indicating if there are pending saves
+ */
+export const useHasPendingSaves = (active: boolean = true): boolean => {
+  const [hasPendingSaves, setHasPendingSaves] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    const checkPendingSaves = () => {
+      setHasPendingSaves(regionSaveManager.hasAnyPendingSaves());
+    };
+
+    checkPendingSaves();
+    const interval = setInterval(checkPendingSaves, 500);
+
+    return () => clearInterval(interval);
+  }, [active]);
+
+  return hasPendingSaves;
+};

--- a/src/hooks/useRefreshMediaCredentials.ts
+++ b/src/hooks/useRefreshMediaCredentials.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from 'react';
+import { services } from '../services';
+import { RefreshMediaCredentials } from '../use-cases/refresh-media-credentials';
+
+interface RefreshMediaCredentialsResult {
+  refreshCredentials: (source: string, peaks: unknown) => Promise<void>;
+  isRefreshing: boolean;
+  error: Error | null;
+}
+
+/**
+ * Hook to refresh media credentials in-place without page reload.
+ * Provides loading state for UI feedback.
+ */
+export const useRefreshMediaCredentials = (): RefreshMediaCredentialsResult => {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refreshCredentials = useCallback(async (source: string, peaks: unknown): Promise<void> => {
+    setIsRefreshing(true);
+    setError(null);
+
+    try {
+      const useCase = new RefreshMediaCredentials({
+        source,
+        peaks,
+        services,
+      });
+      await useCase.execute();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error('Failed to refresh credentials');
+      setError(error);
+      throw error;
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  return { refreshCredentials, isRefreshing, error };
+};

--- a/src/services/transcriptionService.ts
+++ b/src/services/transcriptionService.ts
@@ -115,7 +115,7 @@ export const generateSignedUrl = async (sourceUrl: string, fileSuffix: string = 
       }
     });
     
-    // Track when this signed URL will expire (60 minutes from now)
+    // Track when this signed URL will expire (60 minutes)
     signedUrlExpirationTime = Date.now() + (3600 * 1000);
     
     return url.toString();

--- a/src/services/wavesurferService.ts
+++ b/src/services/wavesurferService.ts
@@ -391,6 +391,56 @@ class WaveSurferService {
     }
   }
 
+
+  /**
+   * Reloads media with fresh signed URL while preserving playback position.
+   * Used when credentials expire to refresh without page reload.
+   */
+  async reloadWithFreshUrl(source: string, peaks: unknown): Promise<void> {
+    if (!this.wavesurfer) {
+      throw new Error('WaveSurfer not initialized');
+    }
+
+    // Save current playback position
+    const currentTime = this.wavesurfer.getCurrentTime();
+    const wasPlaying = this.wavesurfer.isPlaying();
+    
+    if (wasPlaying) {
+      this.wavesurfer.pause();
+    }
+
+    try {
+      // Generate fresh signed URL
+      const signedMediaUrl = await generateSignedUrl(source);
+      
+      if (this.currentMediaElement) {
+        this.currentMediaElement.src = signedMediaUrl;
+        this.wavesurfer.load(signedMediaUrl, peaks as (Float32Array)[]);
+      } else {
+        this.wavesurfer.load(signedMediaUrl, peaks as (Float32Array)[]);
+      }
+
+      // Wait for ready event before seeking
+      await new Promise<void>((resolve) => {
+        const onReady = () => {
+          this.wavesurfer?.un('ready', onReady);
+          resolve();
+        };
+        this.wavesurfer?.on('ready', onReady);
+      });
+
+      // Restore playback position
+      this.wavesurfer.setTime(currentTime);
+      
+      if (wasPlaying) {
+        this.wavesurfer.play();
+      }
+    } catch (error) {
+      console.error('Failed to reload media with fresh URL:', error);
+      throw error;
+    }
+  }
+
   setRegions(regions: RegionEvent[]) {
     if (this.wavesurfer) {
       if (this.ready) {

--- a/src/use-cases/refresh-media-credentials.test.ts
+++ b/src/use-cases/refresh-media-credentials.test.ts
@@ -1,0 +1,146 @@
+import { RefreshMediaCredentials } from './refresh-media-credentials';
+import { services } from '../services';
+
+// Mock the services
+jest.mock('../services');
+
+describe('RefreshMediaCredentials', () => {
+  let mockTranscriptionService: any;
+  let mockWavesurferService: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock transcriptionService
+    mockTranscriptionService = {
+      forceFreshCredentials: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // Mock wavesurferService
+    mockWavesurferService = {
+      reloadWithFreshUrl: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // Setup services mock
+    (services as any).transcriptionService = mockTranscriptionService;
+    (services as any).wavesurferService = mockWavesurferService;
+  });
+
+  describe('validate', () => {
+    it('should throw error when source is missing', () => {
+      const useCase = new RefreshMediaCredentials({
+        source: '',
+        peaks: [1, 2, 3],
+        services,
+      });
+
+      expect(() => useCase.validate()).toThrow('Media source is required');
+    });
+
+    it('should not throw when source is provided', () => {
+      const useCase = new RefreshMediaCredentials({
+        source: 'https://example.com/media.mp3',
+        peaks: [1, 2, 3],
+        services,
+      });
+
+      expect(() => useCase.validate()).not.toThrow();
+    });
+  });
+
+  describe('execute', () => {
+    it('should force fresh credentials and reload media', async () => {
+      const useCase = new RefreshMediaCredentials({
+        source: 'https://example.com/media.mp3',
+        peaks: [1, 2, 3],
+        services,
+      });
+
+      await useCase.execute();
+
+      expect(mockTranscriptionService.forceFreshCredentials).toHaveBeenCalledTimes(1);
+      expect(mockWavesurferService.reloadWithFreshUrl).toHaveBeenCalledWith(
+        'https://example.com/media.mp3',
+        [1, 2, 3]
+      );
+    });
+
+    it('should call forceFreshCredentials before reloading media', async () => {
+      const callOrder: string[] = [];
+
+      mockTranscriptionService.forceFreshCredentials.mockImplementation(async () => {
+        callOrder.push('forceFreshCredentials');
+      });
+
+      mockWavesurferService.reloadWithFreshUrl.mockImplementation(async () => {
+        callOrder.push('reloadWithFreshUrl');
+      });
+
+      const useCase = new RefreshMediaCredentials({
+        source: 'https://example.com/media.mp3',
+        peaks: [1, 2, 3],
+        services,
+      });
+
+      await useCase.execute();
+
+      expect(callOrder).toEqual(['forceFreshCredentials', 'reloadWithFreshUrl']);
+    });
+
+    it('should throw validation error before making any calls', async () => {
+      const useCase = new RefreshMediaCredentials({
+        source: '',
+        peaks: [1, 2, 3],
+        services,
+      });
+
+      await expect(useCase.execute()).rejects.toThrow('Media source is required');
+
+      expect(mockTranscriptionService.forceFreshCredentials).not.toHaveBeenCalled();
+      expect(mockWavesurferService.reloadWithFreshUrl).not.toHaveBeenCalled();
+    });
+
+    it('should propagate error from forceFreshCredentials', async () => {
+      const error = new Error('Failed to refresh credentials');
+      mockTranscriptionService.forceFreshCredentials.mockRejectedValue(error);
+
+      const useCase = new RefreshMediaCredentials({
+        source: 'https://example.com/media.mp3',
+        peaks: [1, 2, 3],
+        services,
+      });
+
+      await expect(useCase.execute()).rejects.toThrow('Failed to refresh credentials');
+      expect(mockWavesurferService.reloadWithFreshUrl).not.toHaveBeenCalled();
+    });
+
+    it('should propagate error from reloadWithFreshUrl', async () => {
+      const error = new Error('Failed to reload media');
+      mockWavesurferService.reloadWithFreshUrl.mockRejectedValue(error);
+
+      const useCase = new RefreshMediaCredentials({
+        source: 'https://example.com/media.mp3',
+        peaks: [1, 2, 3],
+        services,
+      });
+
+      await expect(useCase.execute()).rejects.toThrow('Failed to reload media');
+      expect(mockTranscriptionService.forceFreshCredentials).toHaveBeenCalled();
+    });
+
+    it('should work with null peaks', async () => {
+      const useCase = new RefreshMediaCredentials({
+        source: 'https://example.com/media.mp3',
+        peaks: null,
+        services,
+      });
+
+      await useCase.execute();
+
+      expect(mockWavesurferService.reloadWithFreshUrl).toHaveBeenCalledWith(
+        'https://example.com/media.mp3',
+        null
+      );
+    });
+  });
+});

--- a/src/use-cases/refresh-media-credentials.ts
+++ b/src/use-cases/refresh-media-credentials.ts
@@ -1,0 +1,47 @@
+import { services } from '../services';
+
+interface RefreshMediaCredentialsConfig {
+  source: string;
+  peaks: unknown;
+  services: typeof services;
+}
+
+/**
+ * Refreshes media credentials in-place without page reload.
+ *
+ * This use-case:
+ * 1. Forces fresh AWS credentials
+ * 2. Reloads media with a new signed URL
+ * 3. Preserves playback position
+ *
+ * Used when signed URLs expire to provide a seamless refresh experience.
+ */
+export class RefreshMediaCredentials {
+  private readonly source: string;
+  private readonly peaks: unknown;
+  private readonly transcriptionService: typeof services.transcriptionService;
+  private readonly wavesurferService: typeof services.wavesurferService;
+
+  constructor(config: RefreshMediaCredentialsConfig) {
+    this.source = config.source;
+    this.peaks = config.peaks;
+    this.transcriptionService = config.services.transcriptionService;
+    this.wavesurferService = config.services.wavesurferService;
+  }
+
+  validate(): void {
+    if (!this.source) {
+      throw new Error('Media source is required');
+    }
+  }
+
+  async execute(): Promise<void> {
+    this.validate();
+
+    // Force fresh AWS credentials
+    await this.transcriptionService.forceFreshCredentials();
+
+    // Reload media with fresh signed URL (preserves playback position)
+    await this.wavesurferService.reloadWithFreshUrl(this.source, this.peaks);
+  }
+}


### PR DESCRIPTION
I _believe_ what's happening is when we prompt the user to "refresh media token" because it has expired, we don't _actually_ get new credentials, so the problem persists. This skips "window.refresh()" and actually just refreshes everything in-place, streamlining the UX a little.

If this goes well, I will probably turn this into an "auto-refresh" because it's automatically getting a new URL and actually updating wavesurfer without reloading the page, that would be an obvious next step. 