### PR TITLE
Move to using spellcheck API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ playwright/.auth/
 playwright-report/
 test-results/
 .env
+.env.local
 debug-*.png
 
 # Claude Flow generated files

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ A docker image is provided to build C bindings if needed. Currently needed when 
 brew install --cask docker
 ```
 
+## Setup Spellcheck API Credentials
+
+The spellcheck API requires a key that is environment-specific. After pulling an environment, run:
+
+```
+npx amplify env checkout <env>
+```
+
+This fetches the `transcribe-<env>` API key from API Gateway and writes `VITE_SPELLCHECK_API_BASE_URL` and `VITE_SPELLCHECK_API_KEY` to `.env.local`. This also runs automatically before `amplify publish`.
+
 ## Setup Amplify and Pull `staging`
 ```
 npx amplify pull

--- a/amplify/hooks/post-checkout-env.js
+++ b/amplify/hooks/post-checkout-env.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/**
+ * Amplify Post-Checkout-Env Hook
+ *
+ * After `amplify env checkout <env>`, this hook fetches the spellcheck API key
+ * for the newly checked-out environment and writes VITE_SPELLCHECK_API_BASE_URL
+ * and VITE_SPELLCHECK_API_KEY to .env.local so local dev and future builds use
+ * the correct key.
+ *
+ * The API key is looked up by name: transcribe-<envName> (e.g. transcribe-staging)
+ * Base URL is derived from the env: staging → api.kiyanaw.dev, production → api.kiyanaw.net
+ */
+
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+function readJsonFile(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+const BASE_URLS = {
+  staging: 'https://api.kiyanaw.dev',
+  production: 'https://api.kiyanaw.net',
+};
+
+// Read hook input from stdin
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const hookData = JSON.parse(input);
+
+    if (hookData.error) {
+      console.log('Amplify encountered an error during env checkout. Skipping spellcheck env setup.');
+      process.exit(0);
+    }
+
+    console.log('\n========================================');
+    console.log('Post-Checkout-Env Hook: Setting up spellcheck API env');
+    console.log('========================================\n');
+
+    // Determine current Amplify environment and AWS profile
+    const localEnvInfo = readJsonFile(path.join(projectRoot, 'amplify', '.config', 'local-env-info.json'));
+    const envName = localEnvInfo.envName;
+
+    const localAwsInfo = readJsonFile(path.join(projectRoot, 'amplify', '.config', 'local-aws-info.json'));
+    const awsProfile = localAwsInfo[envName]?.profileName || 'default';
+
+    console.log(`Environment: ${envName}`);
+    console.log(`AWS Profile: ${awsProfile}`);
+
+    const baseUrl = BASE_URLS[envName];
+    if (!baseUrl) {
+      console.warn(`Warning: No spellcheck base URL configured for env "${envName}". Skipping.`);
+      process.exit(0);
+    }
+
+    // Fetch the API key value from API Gateway by name
+    const keyName = `transcribe-${envName}`;
+    console.log(`\nFetching API key "${keyName}" from API Gateway...`);
+
+    const apiKeyJson = execSync(
+      `aws apigateway get-api-keys --name-query "${keyName}" --include-values --query 'items[0].value' --output text --profile ${awsProfile} --region us-east-1`,
+      { cwd: projectRoot }
+    ).toString().trim();
+
+    if (!apiKeyJson || apiKeyJson === 'None') {
+      console.error(`Error: API key "${keyName}" not found in API Gateway.`);
+      process.exit(1);
+    }
+
+    // Write .env.local
+    const envLocalPath = path.join(projectRoot, '.env.local');
+    let existing = '';
+    try {
+      existing = readFileSync(envLocalPath, 'utf8');
+    } catch {
+      // File doesn't exist yet, start fresh
+    }
+
+    // Replace or append each variable
+    function setEnvVar(content, key, value) {
+      const line = `${key}=${value}`;
+      const regex = new RegExp(`^${key}=.*$`, 'm');
+      return regex.test(content) ? content.replace(regex, line) : content + (content.endsWith('\n') || content === '' ? '' : '\n') + line + '\n';
+    }
+
+    let updated = existing;
+    updated = setEnvVar(updated, 'VITE_SPELLCHECK_API_BASE_URL', baseUrl);
+    updated = setEnvVar(updated, 'VITE_SPELLCHECK_API_KEY', apiKeyJson);
+
+    writeFileSync(envLocalPath, updated);
+
+    console.log(`\nWrote to .env.local:`);
+    console.log(`  VITE_SPELLCHECK_API_BASE_URL=${baseUrl}`);
+    console.log(`  VITE_SPELLCHECK_API_KEY=<redacted>`);
+
+    console.log('\n========================================');
+    console.log('Spellcheck env setup complete.');
+    console.log('========================================\n');
+
+    process.exit(0);
+  } catch (error) {
+    console.error('\nError in post-checkout-env hook:', error.message);
+    process.exit(0);
+  }
+});

--- a/amplify/hooks/pre-publish.js
+++ b/amplify/hooks/pre-publish.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+/**
+ * Amplify Pre-Publish Hook
+ *
+ * Before `amplify publish` builds the frontend, this hook fetches the spellcheck
+ * API key from API Gateway and writes VITE_SPELLCHECK_API_BASE_URL and
+ * VITE_SPELLCHECK_API_KEY to .env.local so Vite bakes them into the build.
+ *
+ * The API key is looked up by name: transcribe-<envName> (e.g. transcribe-staging)
+ * Base URL is derived from the env: staging → api.kiyanaw.dev, production → api.kiyanaw.net
+ */
+
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+function readJsonFile(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+const BASE_URLS = {
+  staging: 'https://api.kiyanaw.dev',
+  production: 'https://api.kiyanaw.net',
+};
+
+// Read hook input from stdin
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const hookData = JSON.parse(input);
+
+    if (hookData.error) {
+      console.log('Amplify encountered an error before pre-publish. Skipping spellcheck env setup.');
+      process.exit(0);
+    }
+
+    console.log('\n========================================');
+    console.log('Pre-Publish Hook: Setting up spellcheck API env');
+    console.log('========================================\n');
+
+    // Determine current Amplify environment and AWS profile
+    const localEnvInfo = readJsonFile(path.join(projectRoot, 'amplify', '.config', 'local-env-info.json'));
+    const envName = localEnvInfo.envName;
+
+    const localAwsInfo = readJsonFile(path.join(projectRoot, 'amplify', '.config', 'local-aws-info.json'));
+    const awsProfile = localAwsInfo[envName]?.profileName || 'default';
+
+    console.log(`Environment: ${envName}`);
+    console.log(`AWS Profile: ${awsProfile}`);
+
+    const baseUrl = BASE_URLS[envName];
+    if (!baseUrl) {
+      console.warn(`Warning: No spellcheck base URL configured for env "${envName}". Skipping.`);
+      process.exit(0);
+    }
+
+    // Fetch the API key value from API Gateway by name
+    const keyName = `transcribe-${envName}`;
+    console.log(`\nFetching API key "${keyName}" from API Gateway...`);
+
+    const apiKeyJson = execSync(
+      `aws apigateway get-api-keys --name-query "${keyName}" --include-values --query 'items[0].value' --output text --profile ${awsProfile} --region us-east-1`,
+      { cwd: projectRoot }
+    ).toString().trim();
+
+    if (!apiKeyJson || apiKeyJson === 'None') {
+      console.error(`Error: API key "${keyName}" not found in API Gateway.`);
+      process.exit(1);
+    }
+
+    // Write .env.local
+    const envLocalPath = path.join(projectRoot, '.env.local');
+    let existing = '';
+    try {
+      existing = readFileSync(envLocalPath, 'utf8');
+    } catch {
+      // File doesn't exist yet, start fresh
+    }
+
+    // Replace or append each variable
+    function setEnvVar(content, key, value) {
+      const line = `${key}=${value}`;
+      const regex = new RegExp(`^${key}=.*$`, 'm');
+      return regex.test(content) ? content.replace(regex, line) : content + (content.endsWith('\n') || content === '' ? '' : '\n') + line + '\n';
+    }
+
+    let updated = existing;
+    updated = setEnvVar(updated, 'VITE_SPELLCHECK_API_BASE_URL', baseUrl);
+    updated = setEnvVar(updated, 'VITE_SPELLCHECK_API_KEY', apiKeyJson);
+
+    writeFileSync(envLocalPath, updated);
+
+    console.log(`\nWrote to .env.local:`);
+    console.log(`  VITE_SPELLCHECK_API_BASE_URL=${baseUrl}`);
+    console.log(`  VITE_SPELLCHECK_API_KEY=<redacted>`);
+
+    console.log('\n========================================');
+    console.log('Spellcheck env setup complete.');
+    console.log('========================================\n');
+
+    process.exit(0);
+  } catch (error) {
+    console.error('\nError in pre-publish hook:', error.message);
+    process.exit(1);
+  }
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ export default {
       displayName: 'Main App',
       preset: 'ts-jest',
       testEnvironment: 'jsdom',
+      setupFiles: ['<rootDir>/src/setupTestGlobals.ts'],
       setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
       moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',

--- a/src/services/spellCheckerService.test.ts
+++ b/src/services/spellCheckerService.test.ts
@@ -1,17 +1,12 @@
 import { spellCheckerService } from './spellCheckerService';
 
-// Mock aws-amplify/api
-jest.mock('aws-amplify/api', () => ({
-  post: jest.fn()
-}));
-
-// Get the mocked function
-const mockPost = jest.mocked(require('aws-amplify/api').post);
+const mockFetch = jest.fn();
+globalThis.fetch = mockFetch;
 
 describe('SpellCheckerService', () => {
   beforeEach(() => {
     spellCheckerService.clearCache();
-    mockPost.mockClear();
+    mockFetch.mockClear();
   });
 
   describe('tokenize', () => {
@@ -43,7 +38,7 @@ describe('SpellCheckerService', () => {
     it('should return empty arrays for empty input', async () => {
       const result = await spellCheckerService.check([]);
       expect(result).toEqual({ known: [], unknown: [], suggestions: [] });
-      expect(mockPost).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('should make API call for unknown words with default language code', async () => {
@@ -53,26 +48,20 @@ describe('SpellCheckerService', () => {
         'êkwa': ['analysis']
       };
 
-      const mockRestOperation = {
-        response: {
-          body: {
-            json: () => Promise.resolve(mockResponse)
-          }
-        }
-      };
-
-      mockPost.mockReturnValueOnce(mockRestOperation);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      });
 
       const result = await spellCheckerService.check(['itwêw', 'hello', 'êkwa']);
-      
-      expect(mockPost).toHaveBeenCalledTimes(1);
-      const callArgs = mockPost.mock.calls[0][0];
-      expect(callArgs.apiName).toBe('spellcheck');
-      expect(callArgs.path).toBe('/bulk-lookup');
-      expect(callArgs.options.body).toEqual({
-        languageCode: 'crk',
-        words: expect.arrayContaining(['itwêw', 'hello', 'êkwa'])
-      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/spellcheck/bulk-lookup');
+      const body = JSON.parse(options.body);
+      expect(body.languageCode).toBe('crk');
+      expect(body.words).toEqual(expect.arrayContaining(['itwêw', 'hello', 'êkwa']));
+      expect(options.headers['x-api-key']).toBeDefined();
       expect(result.known).toEqual(expect.arrayContaining([
         expect.objectContaining({ word: 'itwêw' }),
         expect.objectContaining({ word: 'êkwa' })
@@ -86,29 +75,18 @@ describe('SpellCheckerService', () => {
         'monde': ['analysis']
       };
 
-      const mockRestOperation = {
-        response: {
-          body: {
-            json: () => Promise.resolve(mockResponse)
-          }
-        }
-      };
-
-      mockPost.mockReturnValueOnce(mockRestOperation);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      });
 
       const result = await spellCheckerService.check(['bonjour', 'monde'], 'fra');
-      
-      expect(mockPost).toHaveBeenCalledTimes(1);
-      expect(mockPost).toHaveBeenCalledWith({
-        apiName: 'spellcheck',
-        path: '/bulk-lookup',
-        options: {
-          body: {
-            languageCode: 'fra',
-            words: ['bonjour', 'monde']
-          }
-        }
-      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.languageCode).toBe('fra');
+      expect(body.words).toEqual(['bonjour', 'monde']);
       expect(result.known).toEqual(expect.arrayContaining([
         expect.objectContaining({ word: 'bonjour' }),
         expect.objectContaining({ word: 'monde' })
@@ -122,19 +100,14 @@ describe('SpellCheckerService', () => {
         'hello': []
       };
 
-      const mockRestOperation = {
-        response: {
-          body: {
-            json: () => Promise.resolve(mockResponse)
-          }
-        }
-      };
-
-      mockPost.mockReturnValueOnce(mockRestOperation);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      });
 
       // First call - should hit API
       const result1 = await spellCheckerService.check(['itwêw', 'hello']);
-      expect(mockPost).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result1.known).toEqual(expect.arrayContaining([
         expect.objectContaining({ word: 'itwêw' })
       ]));
@@ -142,7 +115,7 @@ describe('SpellCheckerService', () => {
 
       // Second call with same words - should use cache
       const result2 = await spellCheckerService.check(['itwêw', 'hello']);
-      expect(mockPost).toHaveBeenCalledTimes(1); // No additional API call
+      expect(mockFetch).toHaveBeenCalledTimes(1); // No additional API call
       expect(result2.known).toEqual(expect.arrayContaining([
         expect.objectContaining({ word: 'itwêw' })
       ]));
@@ -151,45 +124,31 @@ describe('SpellCheckerService', () => {
 
     it('should only request unknown words from API', async () => {
       // First request
-      const mockResponse1 = { 'itwêw': ['data'], 'hello': [] };
-      const mockRestOperation1 = {
-        response: {
-          body: {
-            json: () => Promise.resolve(mockResponse1)
-          }
-        }
-      };
-      mockPost.mockReturnValueOnce(mockRestOperation1);
-
-      await spellCheckerService.check(['itwêw', 'hello']);
-      expect(mockPost).toHaveBeenCalledTimes(1);
-
-      // Second request with mix of known and unknown words
-      const mockResponse2 = { 'êkwa': ['data'], 'world': [] };
-      const mockRestOperation2 = {
-        response: {
-          body: {
-            json: () => Promise.resolve(mockResponse2)
-          }
-        }
-      };
-      mockPost.mockReturnValueOnce(mockRestOperation2);
-
-      const result = await spellCheckerService.check(['itwêw', 'hello', 'êkwa', 'world']);
-      
-      // Should only request the unknown words
-      expect(mockPost).toHaveBeenCalledTimes(2);
-      const lastCallArgs = mockPost.mock.calls[1][0];
-      expect(lastCallArgs.apiName).toBe('spellcheck');
-      expect(lastCallArgs.path).toBe('/bulk-lookup');
-      expect(lastCallArgs.options.body).toEqual({
-        languageCode: 'crk',
-        words: expect.arrayContaining(['êkwa', 'world'])
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ 'itwêw': ['data'], 'hello': [] })
       });
 
+      await spellCheckerService.check(['itwêw', 'hello']);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Second request with mix of known and unknown words
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ 'êkwa': ['data'], 'world': [] })
+      });
+
+      const result = await spellCheckerService.check(['itwêw', 'hello', 'êkwa', 'world']);
+
+      // Should only request the unknown words
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [, options] = mockFetch.mock.calls[1];
+      const body = JSON.parse(options.body);
+      expect(body.words).toEqual(expect.arrayContaining(['êkwa', 'world']));
+
       expect(result.known).toEqual(expect.arrayContaining([
-        expect.objectContaining({ word: 'itwêw', analysis: 'data', allAnalysis: ['data'] }), // From cache - preserves full analysis
-        expect.objectContaining({ word: 'êkwa', analysis: 'data', allAnalysis: ['data'] }) // Fresh from API
+        expect.objectContaining({ word: 'itwêw', analysis: 'data', allAnalysis: ['data'] }),
+        expect.objectContaining({ word: 'êkwa', analysis: 'data', allAnalysis: ['data'] })
       ]));
       expect(result.unknown).toEqual(['hello', 'world']);
     });
@@ -200,19 +159,14 @@ describe('SpellCheckerService', () => {
         'pitamâ': ['pitamâ+Ipc']
       };
 
-      const mockRestOperation = {
-        response: {
-          body: {
-            json: () => Promise.resolve(mockResponse)
-          }
-        }
-      };
-
-      mockPost.mockReturnValueOnce(mockRestOperation);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      });
 
       // First call - should hit API
       const result1 = await spellCheckerService.check(['ôma', 'pitamâ']);
-      expect(mockPost).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result1.known).toEqual([
         { word: 'ôma', analysis: 'ôma+Ipc', allAnalysis: ['ôma+Ipc', 'ôma+Pron+Dem+Prox+I+Sg'] },
         { word: 'pitamâ', analysis: 'pitamâ+Ipc', allAnalysis: ['pitamâ+Ipc'] }
@@ -220,9 +174,8 @@ describe('SpellCheckerService', () => {
 
       // Second call with same words - should use cache and PRESERVE full analysis
       const result2 = await spellCheckerService.check(['ôma', 'pitamâ']);
-      expect(mockPost).toHaveBeenCalledTimes(1); // No additional API call
+      expect(mockFetch).toHaveBeenCalledTimes(1); // No additional API call
 
-      // CRITICAL: Cached words should retain their full analysis data
       expect(result2.known).toEqual([
         { word: 'ôma', analysis: 'ôma+Ipc', allAnalysis: ['ôma+Ipc', 'ôma+Pron+Dem+Prox+I+Sg'] },
         { word: 'pitamâ', analysis: 'pitamâ+Ipc', allAnalysis: ['pitamâ+Ipc'] }
@@ -230,21 +183,17 @@ describe('SpellCheckerService', () => {
     });
 
     it('should handle API errors gracefully', async () => {
-      mockPost.mockImplementationOnce(() => Promise.reject(new Error('Network error')));
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
       await expect(spellCheckerService.check(['itwêw', 'hello'])).resolves.toEqual({ known: [], unknown: ['itwêw', 'hello'], suggestions: [] });
     });
 
     it('should deduplicate identical concurrent requests', async () => {
       const mockResponse = { 'itwêw': ['data'], 'hello': [] };
-      const mockRestOperation = {
-        response: {
-          body: {
-            json: () => Promise.resolve(mockResponse)
-          }
-        }
-      };
-      mockPost.mockReturnValueOnce(mockRestOperation);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse)
+      });
 
       // Make multiple concurrent requests with same words
       const promises = [
@@ -254,10 +203,10 @@ describe('SpellCheckerService', () => {
       ];
 
       const results = await Promise.all(promises);
-      
+
       // Should only make one API call despite multiple concurrent requests
-      expect(mockPost).toHaveBeenCalledTimes(1);
-      
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
       // All results should be identical
       results.forEach(result => {
         expect(result.known).toEqual(expect.arrayContaining([
@@ -274,32 +223,20 @@ describe('SpellCheckerService', () => {
         { word: 'itwêw', analysis: 'itwêw+V+AI+Ind+3Sg', allAnalysis: ['itwêw+V+AI+Ind+3Sg'] },
         { word: 'êkwa', analysis: 'êkwa+Ipc', allAnalysis: ['êkwa+Ipc'] }
       ]);
-      
-      // Mock the API response for the 'hello' word
-      const mockResponse = { 'hello': [] };
-      const mockRestOperation = {
-        response: {
-          body: {
-            json: () => Promise.resolve(mockResponse)
-          }
-        }
-      };
-      mockPost.mockReturnValueOnce(mockRestOperation);
-      
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ 'hello': [] })
+      });
+
       // These words should now be cached as known
       const result = await spellCheckerService.check(['itwêw', 'êkwa', 'hello']);
-      
+
       // Should only request 'hello' from API
-      expect(mockPost).toHaveBeenCalledWith({
-        apiName: 'spellcheck',
-        path: '/bulk-lookup',
-        options: {
-          body: {
-            languageCode: 'crk',
-            words: ['hello']
-          }
-        }
-      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.words).toEqual(['hello']);
     });
   });
 
@@ -321,15 +258,15 @@ describe('SpellCheckerService', () => {
     beforeEach(() => {
       // Create a global known words map
       globalKnownWords = new Map();
-      globalKnownWords.set('isi', { 
-        word: 'isi', 
-        analysis: 'isi+Ipc', 
-        allAnalysis: ['itêw+V+TA+Imp+Imm+2Sg+3SgO', 'isi+Ipc'] 
+      globalKnownWords.set('isi', {
+        word: 'isi',
+        analysis: 'isi+Ipc',
+        allAnalysis: ['itêw+V+TA+Imp+Imm+2Sg+3SgO', 'isi+Ipc']
       });
-      globalKnownWords.set('foo', { 
-        word: 'foo', 
-        analysis: 'foo+N', 
-        allAnalysis: ['foo+N'] 
+      globalKnownWords.set('foo', {
+        word: 'foo',
+        analysis: 'foo+N',
+        allAnalysis: ['foo+N']
       });
     });
 
@@ -342,7 +279,7 @@ describe('SpellCheckerService', () => {
       // Should have 3 entries for known words: foo, isi, isi
       // ('and' and 'another' are not in globalKnownWords)
       expect(result.analysis).toHaveLength(3);
-      
+
       // Check that we have two separate 'isi' entries with different indices
       const isiEntries = result.analysis.filter(item => item.word === 'isi');
       expect(isiEntries).toHaveLength(2);
@@ -380,23 +317,20 @@ describe('SpellCheckerService', () => {
       const result = await spellCheckerService.analyzeRegionText(regionText, 'crk', globalKnownWords, existingAnalysis);
 
       expect(result.analysis).toHaveLength(3);
-      
-      // First 'isi' should preserve 'user' source
+
       expect(result.analysis[0]).toMatchObject({
         word: 'isi',
         source: 'user',
         analysis: 'itêw+V+TA+Imp+Imm+2Sg+3SgO',
         index: 0
       });
-      
-      // Second 'foo' should preserve 'auto' source
+
       expect(result.analysis[1]).toMatchObject({
         word: 'foo',
         source: 'auto',
         index: 1
       });
-      
-      // Third 'isi' should preserve 'auto' source
+
       expect(result.analysis[2]).toMatchObject({
         word: 'isi',
         source: 'auto',
@@ -415,24 +349,21 @@ describe('SpellCheckerService', () => {
       const result = await spellCheckerService.analyzeRegionText(regionText, 'crk', globalKnownWords, existingAnalysis);
 
       expect(result.analysis).toHaveLength(3);
-      
-      // First 'isi' - user selected first analysis
+
       expect(result.analysis[0]).toMatchObject({
         word: 'isi',
         source: 'user',
         analysis: 'itêw+V+TA+Imp+Imm+2Sg+3SgO',
         index: 0
       });
-      
-      // Second 'isi' - auto selected
+
       expect(result.analysis[1]).toMatchObject({
         word: 'isi',
         source: 'auto',
         analysis: 'isi+Ipc',
         index: 1
       });
-      
-      // Third 'isi' - user selected second analysis
+
       expect(result.analysis[2]).toMatchObject({
         word: 'isi',
         source: 'user',
@@ -442,7 +373,6 @@ describe('SpellCheckerService', () => {
     });
 
     it('should not carry over source from one region to another', async () => {
-      // Create a global cache with a user-selected word
       const globalWithUserSelection = new Map(globalKnownWords);
       globalWithUserSelection.set('test', {
         word: 'test',
@@ -457,7 +387,6 @@ describe('SpellCheckerService', () => {
       const result = await spellCheckerService.analyzeRegionText(regionText, 'crk', globalWithUserSelection, existingAnalysis);
 
       expect(result.analysis).toHaveLength(1);
-      // Should be 'auto' in new region, not 'user'
       expect(result.analysis[0]).toMatchObject({
         word: 'test',
         source: 'auto',
@@ -465,4 +394,4 @@ describe('SpellCheckerService', () => {
       });
     });
   });
-}); 
+});

--- a/src/services/spellCheckerService.ts
+++ b/src/services/spellCheckerService.ts
@@ -1,5 +1,7 @@
-import { post } from 'aws-amplify/api';
 import type { WordAnalysis, SpellCheckResult, SpellingSuggestion } from './adt';
+
+declare const __SPELLCHECK_BASE_URL__: string;
+declare const __SPELLCHECK_API_KEY__: string;
 
 class SpellCheckerServiceImpl {
   private knownWordsCache = new Map<string, WordAnalysis>(); // Cache full analysis by word
@@ -59,20 +61,20 @@ class SpellCheckerServiceImpl {
 
   private async makeApiRequest(words: string[], languageCode: string): Promise<SpellCheckResult> {
     try {
-      // Use Amplify's REST API client with the spellcheck API
-      // New endpoint format: /bulk-lookup with languageCode in body
-      const { response } = await post({
-        apiName: 'spellcheck',
-        path: '/bulk-lookup',
-        options: {
-          body: {
-            languageCode,
-            words
-          }
-        }
+      const response = await fetch(`${__SPELLCHECK_BASE_URL__}/spellcheck/bulk-lookup`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': __SPELLCHECK_API_KEY__,
+        },
+        body: JSON.stringify({ languageCode, words }),
       });
-      const res = await response;
-      const result = await res.body.json() as Record<string, string[] | { word: string; analysis: string }[]>;
+
+      if (!response.ok) {
+        throw new Error(`Spellcheck API error: ${response.status}`);
+      }
+
+      const result = await response.json() as Record<string, string[] | { word: string; analysis: string }[]>;
       
       // Parse API response - keys are words, values are arrays of analyses
       const known: WordAnalysis[] = [];

--- a/src/setupTestGlobals.ts
+++ b/src/setupTestGlobals.ts
@@ -1,2 +1,11 @@
-(globalThis as any).__SPELLCHECK_BASE_URL__ = 'https://api.kiyanaw.dev';
-(globalThis as any).__SPELLCHECK_API_KEY__ = 'test-key';
+export {};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __SPELLCHECK_BASE_URL__: string;
+  // eslint-disable-next-line no-var
+  var __SPELLCHECK_API_KEY__: string;
+}
+
+globalThis.__SPELLCHECK_BASE_URL__ = 'https://api.kiyanaw.dev';
+globalThis.__SPELLCHECK_API_KEY__ = 'test-key';

--- a/src/setupTestGlobals.ts
+++ b/src/setupTestGlobals.ts
@@ -1,0 +1,2 @@
+(globalThis as any).__SPELLCHECK_BASE_URL__ = 'https://api.kiyanaw.dev';
+(globalThis as any).__SPELLCHECK_API_KEY__ = 'test-key';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,3 +3,5 @@
 // Build-time constants injected by Vite
 declare const __BUILD_HASH__: string;
 declare const __BUILD_TIME__: string;
+declare const __SPELLCHECK_BASE_URL__: string;
+declare const __SPELLCHECK_API_KEY__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import commonjs from 'vite-plugin-commonjs'
@@ -19,7 +19,9 @@ const buildHash = generateBuildHash();
 const buildTime = new Date().toISOString();
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
   resolve: {
     // Enable symlink resolution for shared code from Lambda
     preserveSymlinks: true,
@@ -33,8 +35,8 @@ export default defineConfig({
   define: {
     __BUILD_HASH__: JSON.stringify(buildHash),
     __BUILD_TIME__: JSON.stringify(buildTime),
-    __SPELLCHECK_BASE_URL__: JSON.stringify(process.env.VITE_SPELLCHECK_API_BASE_URL ?? ''),
-    __SPELLCHECK_API_KEY__: JSON.stringify(process.env.VITE_SPELLCHECK_API_KEY ?? ''),
+    __SPELLCHECK_BASE_URL__: JSON.stringify(env.VITE_SPELLCHECK_API_BASE_URL ?? ''),
+    __SPELLCHECK_API_KEY__: JSON.stringify(env.VITE_SPELLCHECK_API_KEY ?? ''),
   },
   plugins: [
     commonjs(),
@@ -111,4 +113,5 @@ export default defineConfig({
       }
     })
   ],
+  };
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
   define: {
     __BUILD_HASH__: JSON.stringify(buildHash),
     __BUILD_TIME__: JSON.stringify(buildTime),
+    __SPELLCHECK_BASE_URL__: JSON.stringify(process.env.VITE_SPELLCHECK_API_BASE_URL ?? ''),
+    __SPELLCHECK_API_KEY__: JSON.stringify(process.env.VITE_SPELLCHECK_API_KEY ?? ''),
   },
   plugins: [
     commonjs(),


### PR DESCRIPTION
Originally this branch was going to port the existing `spellcheck` lambda managed by amplify to python to add support for weighted transducers. This proved to be impossible because amplify gen 1 only supports uploading zip files to create lambdas and with the new library it was too large.

This PR now switches from spellchecking with the existing lambda to using the new spellcheck API.

API credentials are created in the other project and pulled into this project with a script. `pre-publish` and `post-checkout-env` hooks have been added to set those credentials locally. Vite will package them in the publish and the local dev will read them from your `.env.local`.

### Testing
- Added new words to existing transcriptions for all currently supported languages
- Edited existing words to trigger suggestions when possible