### PR TITLE
Cleanup waveform processing

### DIFF
--- a/amplify/backend/function/createPeaksFile/src/lib/audio.js
+++ b/amplify/backend/function/createPeaksFile/src/lib/audio.js
@@ -41,15 +41,22 @@ const extractAudioFromVideo = async (inputPath, outputPath) => {
  * @returns {Promise<string>} - Path to the generated JSON file
  */
 const generateWaveform = async (audioPath) => {
-  const datPath = `${audioPath}.dat`
+  const wavPath = `${audioPath}.wav`
   const jsonPath = `${audioPath}.json`
-  
-  // Generate waveform data
-  await runCommand(`audiowaveform -i ${escapeShellArg(audioPath)} -o ${escapeShellArg(datPath)} --pixels-per-second 20`)
-  
-  // Convert to JSON
-  await runCommand(`audiowaveform -i ${escapeShellArg(datPath)} -o ${escapeShellArg(jsonPath)}`)
-  
+
+  // Decode to PCM WAV at a fixed sample rate before generating peaks.
+  // audiowaveform can misdetect the sample_rate of VBR MP3s or files encoded
+  // at non-standard rates (48000, 22050 Hz, etc.), causing the waveform
+  // timeline to drift from actual playback. ffmpeg decodes reliably.
+  await runCommand(`ffmpeg -i ${escapeShellArg(audioPath)} -acodec pcm_s16le -ar 44100 -ac 1 ${escapeShellArg(wavPath)}`)
+
+  // Generate waveform JSON directly from the normalised WAV
+  await runCommand(`audiowaveform -i ${escapeShellArg(wavPath)} -o ${escapeShellArg(jsonPath)} --pixels-per-second 20`)
+
+  if (fs.existsSync(wavPath)) {
+    fs.unlinkSync(wavPath)
+  }
+
   return jsonPath
 }
 

--- a/amplify/backend/function/createPeaksFile/src/lib/peaks.js
+++ b/amplify/backend/function/createPeaksFile/src/lib/peaks.js
@@ -47,7 +47,6 @@ const processPeaksFile = async (url) => {
     // Generate waveform data
     const jsonPath = await audio.generateWaveform(pathToAudio)
     filesToCleanup.push(jsonPath)
-    filesToCleanup.push(`${pathToAudio}.dat`)
     
     // Process the peaks data
     const processedPeaks = await audio.processPeaksData(jsonPath)

--- a/amplify/backend/function/createPeaksFile/src/test/test-audio.js
+++ b/amplify/backend/function/createPeaksFile/src/test/test-audio.js
@@ -6,7 +6,8 @@ const mockExec = jest.fn()
 // Mock fs
 const mockFs = {
   readFileSync: jest.fn(),
-  existsSync: jest.fn()
+  existsSync: jest.fn(),
+  unlinkSync: jest.fn()
 }
 
 // Mock the modules
@@ -70,15 +71,18 @@ describe('audio utilities', function () {
   describe('generateWaveform()', function () {
     it('should generate waveform data', async function () {
       const result = await audio.generateWaveform('/path/audio.mp3')
-      
+
       assert.equal(mockExec.mock.calls.length, 2)
-      
-      // First call - generate dat file
-      assert.equal(mockExec.mock.calls[0][0], "audiowaveform -i '/path/audio.mp3' -o '/path/audio.mp3.dat' --pixels-per-second 20")
-      
-      // Second call - convert to JSON
-      assert.equal(mockExec.mock.calls[1][0], "audiowaveform -i '/path/audio.mp3.dat' -o '/path/audio.mp3.json'")
-      
+
+      // First call - decode to normalised WAV so audiowaveform gets correct sample rate
+      assert.equal(mockExec.mock.calls[0][0], "ffmpeg -i '/path/audio.mp3' -acodec pcm_s16le -ar 44100 -ac 1 '/path/audio.mp3.wav'")
+
+      // Second call - generate JSON directly from WAV
+      assert.equal(mockExec.mock.calls[1][0], "audiowaveform -i '/path/audio.mp3.wav' -o '/path/audio.mp3.json' --pixels-per-second 20")
+
+      // WAV temp file cleaned up
+      assert.ok(mockFs.unlinkSync.mock.calls.some(call => call[0] === '/path/audio.mp3.wav'))
+
       assert.equal(result, '/path/audio.mp3.json')
     })
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "react-quill": "^2.0.0",
         "react-router-dom": "^6.26.2",
         "smart-timeout": "^2.7.1",
-        "wavesurfer.js": "^7.9.5",
+        "wavesurfer.js": "^7.12.7",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -23864,9 +23864,10 @@
       }
     },
     "node_modules/wavesurfer.js": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.9.5.tgz",
-      "integrity": "sha512-ioOG9chuAn0bF2NYYKkZtaxjcQK/hFskLg8ViLYbJHhWPk1N5wWtuqVhqeh2ZWT2SK3t0E8UkD7lLDLuZQQaSA=="
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.12.7.tgz",
+      "integrity": "sha512-TIe7hB6OCZysNOZ2cn2NR8Qpko22POWel6rauNcqOammFoH65NYQUM35unNLLMIlUMVYvjJ6w/TTl/G/m+w0nA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-quill": "^2.0.0",
     "react-router-dom": "^6.26.2",
     "smart-timeout": "^2.7.1",
-    "wavesurfer.js": "^7.9.5",
+    "wavesurfer.js": "^7.12.7",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/src/components/forms/TranscriptionSettingsPage.tsx
+++ b/src/components/forms/TranscriptionSettingsPage.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
-import { FileText, Users, Settings, Mail, Send, UserPlus, Trash2, Save, RotateCcw, Loader2, AlertTriangle, Download } from 'lucide-react';
+import { FileText, Users, Settings, Mail, Send, UserPlus, Trash2, Save, RotateCcw, Loader2, AlertTriangle, Download, RefreshCw } from 'lucide-react';
 import { useCreateInvite } from '../../hooks/useCreateInvite';
 import { useRevokeInvite } from '../../hooks/useRevokeInvite';
 import { useDeleteTranscription } from '../../hooks/useDeleteTranscription';
 import * as inviteService from '../../services/inviteService';
-import { generateSignedUrl } from '../../services/transcriptionService';
+import { generateSignedUrl, updateTranscription, deletePeaksFile, reloadPeaks } from '../../services/transcriptionService';
+import { currentUserFriendly } from '../../services/userService';
+import { useEditorStore } from '../../stores/useEditorStore';
+import { wavesurferService } from '../../services/wavesurferService';
 import type { InviteModel, TranscriptionModel } from '../../services/adt';
 import { useExportTranscription } from '../../hooks/useExportTranscription';
 import type { ExportRegion } from '../../use-cases/export-transcription';
@@ -62,6 +65,11 @@ export const TranscriptionSettingsPage = ({
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   
+  // Regenerate waveform state
+  type RegenerateStatus = 'idle' | 'working' | 'done' | 'error';
+  const [regenerateStatus, setRegenerateStatus] = useState<RegenerateStatus>('idle');
+  const [regenerateError, setRegenerateError] = useState<string | null>(null);
+
   // Download state
   const [isDownloadingSource, setIsDownloadingSource] = useState(false);
   const [showExportDialog, setShowExportDialog] = useState(false);
@@ -274,6 +282,35 @@ export const TranscriptionSettingsPage = ({
       // Could add error state/toast here if needed
     } finally {
       setIsDownloadingSource(false);
+    }
+  };
+
+  const handleRegeneratePeaks = async () => {
+    if (!transcription.source) return;
+    setRegenerateStatus('working');
+    setRegenerateError(null);
+
+    try {
+      // Remove the existing peaks file so the lambda won't skip regeneration
+      await deletePeaksFile(transcription.source);
+
+      // Touch the record — fires the DynamoDB stream which triggers createPeaksFile
+      await updateTranscription(transcriptionId, {
+        userLastUpdated: currentUserFriendly() || 'unknown',
+      });
+
+      // Poll until the lambda finishes writing the new file
+      const { data: newPeaks, duration: newDuration } = await reloadPeaks(transcription.source);
+
+      // Update the store and reload the waveform without a page refresh
+      useEditorStore.getState().setPeaks(newPeaks);
+      await wavesurferService.load(transcription.source, newPeaks, newDuration);
+
+      setRegenerateStatus('done');
+    } catch (error) {
+      console.error('Failed to regenerate peaks:', error);
+      setRegenerateError(error instanceof Error ? error.message : 'Failed to regenerate waveform');
+      setRegenerateStatus('error');
     }
   };
 
@@ -579,6 +616,35 @@ export const TranscriptionSettingsPage = ({
                     Export transcription
                   </button>
                 </div>
+                {transcription.source && (
+                  <div className="flex flex-col gap-2">
+                    <div>
+                      <button
+                        onClick={handleRegeneratePeaks}
+                        disabled={regenerateStatus === 'working'}
+                        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-orange-600 bg-orange-50 border border-orange-200 rounded-lg hover:bg-orange-100 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      >
+                        {regenerateStatus === 'working' ? (
+                          <>
+                            <Loader2 size={16} className="animate-spin" />
+                            Regenerating...
+                          </>
+                        ) : (
+                          <>
+                            <RefreshCw size={16} />
+                            Regenerate waveform
+                          </>
+                        )}
+                      </button>
+                    </div>
+                    {regenerateStatus === 'done' && (
+                      <p className="text-sm text-green-600">Waveform regenerated successfully.</p>
+                    )}
+                    {regenerateStatus === 'error' && regenerateError && (
+                      <p className="text-sm text-red-600">{regenerateError}</p>
+                    )}
+                  </div>
+                )}
                 {exportError && (
                   <p className="text-sm text-red-600">{exportError}</p>
                 )}

--- a/src/components/player/WaveformPlayer.test.tsx
+++ b/src/components/player/WaveformPlayer.test.tsx
@@ -210,6 +210,7 @@ describe('WaveformPlayer', () => {
         setRegionSelection: jest.fn(),
         regionCursorWords: {},
         setRegionCursorWord: jest.fn(),
+        setPeaks: jest.fn(),
       };
       return selector(state);
     });
@@ -649,6 +650,7 @@ describe('WaveformPlayer', () => {
         setRegionSelection: jest.fn(),
         regionCursorWords: {},
         setRegionCursorWord: jest.fn(),
+        setPeaks: jest.fn(),
       };
       
       mockUseEditorStore.mockImplementation((selector) => selector(mockStateWithNoEdit));
@@ -778,6 +780,7 @@ describe('WaveformPlayer', () => {
         setRegionSelection: jest.fn(),
         regionCursorWords: {},
         setRegionCursorWord: jest.fn(),
+        setPeaks: jest.fn(),
         };
         return selector(state);
       });

--- a/src/services/transcriptionService.test.ts
+++ b/src/services/transcriptionService.test.ts
@@ -86,10 +86,10 @@ describe('TranscriptionService', () => {
     // Setup userService mock
     (currentUser as jest.Mock).mockReturnValue({ userId: 'test-user-id' });
     
-    // Setup fetch mock for peaks data
+    // Setup fetch mock for peaks data (length=100 → duration = 100/20 = 5s)
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: jest.fn().mockResolvedValue({ data: mockPeaksData }),
+      json: jest.fn().mockResolvedValue({ data: mockPeaksData, length: 100 }),
     });
 
     // Mock getUrl from aws-amplify/storage - make it dynamic based on input
@@ -169,6 +169,7 @@ describe('TranscriptionService', () => {
       expect(result).toEqual({
         transcription: expect.objectContaining(mockRawTranscription),
         peaks: mockPeaksData,
+        peaksDuration: 5,
         regions: mockRegions,
         issues: mockIssues,
         comments: [],
@@ -375,6 +376,7 @@ describe('TranscriptionService', () => {
       expect(result).toEqual({
         transcription: expect.objectContaining(mockRawTranscription),
         peaks: mockPeaksData,
+        peaksDuration: 5,
         regions: mockRegions,
         issues: mockIssues,
         comments: [],

--- a/src/services/transcriptionService.ts
+++ b/src/services/transcriptionService.ts
@@ -1,5 +1,5 @@
 import { generateClient, post } from 'aws-amplify/api';
-import { getUrl } from 'aws-amplify/storage';
+import { getUrl, remove } from 'aws-amplify/storage';
 import { fetchAuthSession } from 'aws-amplify/auth';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - GraphQL queries are generated as JS files
@@ -265,44 +265,67 @@ const generateSignedPeaksUrl = async (sourceUrl: string): Promise<string> => {
 };
 
 /**
+ * Deletes the peaks JSON file from S3 so the lambda will regenerate it on the next
+ * DynamoDB stream event.
+ */
+export const deletePeaksFile = async (sourceUrl: string): Promise<void> => {
+  const fileKey = extractS3KeyFromUrl(sourceUrl);
+  const path = `public/${fileKey}.json`;
+  await remove({ path });
+};
+
+/**
+ * Polls S3 until a freshly-generated peaks file is available.
+ * Delegates to fetchPeaksData which uses exponential backoff.
+ */
+export const reloadPeaks = (source: string): Promise<{ data: number[]; duration: number }> => {
+  return fetchPeaksData(source);
+};
+
+const PEAKS_PER_SECOND = 20;
+
+/**
  * Fetches peaks data for a given audio/video source with retry logic.
  * @param source The source URL of the media file
  * @param maxRetries Maximum number of retry attempts
  * @param baseDelay Base delay in milliseconds between retries
- * @returns The peaks data array
+ * @returns The peaks data array and the authoritative duration derived from peak count
  */
 const fetchPeaksData = async (
-  source: string, 
-  maxRetries: number = 10, 
+  source: string,
+  maxRetries: number = 10,
   baseDelay: number = 2000
-): Promise<number[]> => {
+): Promise<{ data: number[]; duration: number }> => {
   let lastError: Error | null = null;
-  
+
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       // Generate signed URL for the peaks file
       const signedPeaksUrl = await generateSignedPeaksUrl(source);
       console.debug(`Fetching peaks data (attempt ${attempt + 1}/${maxRetries + 1}): ${signedPeaksUrl}`);
-      
+
       const peaksResponse = await fetch(signedPeaksUrl);
-      
+
       if (peaksResponse.ok) {
         const peaksObject = await peaksResponse.json();
         console.debug('✅ Peaks data loaded successfully');
-        
-        // WaveSurfer expects the raw array of peaks, not the wrapper object.
+
         if (peaksObject && peaksObject.data) {
-          return peaksObject.data;
+          const duration = peaksObject.length / PEAKS_PER_SECOND;
+          console.debug(`📊 Peaks: ${peaksObject.length} samples → duration ${duration.toFixed(3)}s`);
+          return { data: peaksObject.data, duration };
         } else {
-          return peaksObject;
+          // Fallback for unexpected format: no authoritative duration available
+          const data = peaksObject as number[];
+          return { data, duration: data.length / PEAKS_PER_SECOND };
         }
       }
-      
+
       // If we get 403/404, the file is likely still being processed
       if (peaksResponse.status === 403 || peaksResponse.status === 404) {
         lastError = new Error(`Peaks file not ready yet (${peaksResponse.status}), will retry...`);
         console.debug(`⏳ ${lastError.message}`);
-        
+
         // Don't retry on the last attempt
         if (attempt < maxRetries) {
           const delay = baseDelay * Math.pow(1.5, attempt); // Exponential backoff
@@ -315,16 +338,16 @@ const fetchPeaksData = async (
         const error = new Error(`Failed to load peaks data: ${peaksResponse.status} ${peaksResponse.statusText}`);
         throw error;
       }
-      
+
     } catch (error) {
       lastError = error as Error;
       console.error(`❌ Attempt ${attempt + 1} failed:`, lastError.message);
-      
+
       // If this is a "failed to load peaks data" error (non-retryable), re-throw immediately
       if (lastError.message.includes('Failed to load peaks data:')) {
         throw lastError;
       }
-      
+
       // Don't retry on the last attempt
       if (attempt < maxRetries) {
         const delay = baseDelay * Math.pow(1.5, attempt); // Exponential backoff
@@ -334,7 +357,7 @@ const fetchPeaksData = async (
       }
     }
   }
-  
+
   // If we've exhausted all retries
   throw new Error(`Failed to load peaks data after ${maxRetries + 1} attempts. The audio file may still be processing. Please try again in a few minutes. Last error: ${lastError?.message}`);
 };
@@ -381,7 +404,7 @@ export const loadInFull = async (transcriptionId: string): Promise<false | LoadT
     throw new Error('Transcription source is required to load peaks data');
   }
   
-  const peaks = await fetchPeaksData(transcription.source);
+  const { data: peaks, duration: peaksDuration } = await fetchPeaksData(transcription.source);
 
   const [regions, issues, comments] = await Promise.all([
     loadRegionsForTranscription(transcriptionId),
@@ -392,6 +415,7 @@ export const loadInFull = async (transcriptionId: string): Promise<false | LoadT
   return {
     transcription: transcription,
     peaks,
+    peaksDuration,
     regions,
     issues,
     comments,

--- a/src/services/wavesurferService.test.ts
+++ b/src/services/wavesurferService.test.ts
@@ -725,7 +725,8 @@ describe('WaveSurferService', () => {
       // Should call wavesurfer load with signed URL
       expect(mockWaveSurferInstance.load).toHaveBeenCalledWith(
         'https://fake.s3.amazonaws.com/public/test-source.mp3',
-        peaks
+        peaks,
+        undefined
       );
     });
 
@@ -746,7 +747,8 @@ describe('WaveSurferService', () => {
       // Should call wavesurfer load with signed URL
       expect(mockWaveSurferInstance.load).toHaveBeenCalledWith(
         'https://fake.s3.amazonaws.com/public/test-video.mp4',
-        peaks
+        peaks,
+        undefined
       );
     });
 
@@ -761,7 +763,7 @@ describe('WaveSurferService', () => {
       await wavesurferService.load(source, peaks);
 
       // Should fallback to original URL
-      expect(mockWaveSurferInstance.load).toHaveBeenCalledWith(source, peaks);
+      expect(mockWaveSurferInstance.load).toHaveBeenCalledWith(source, peaks, undefined);
 
       spy.mockRestore();
     });
@@ -779,7 +781,7 @@ describe('WaveSurferService', () => {
 
       // Should fallback to original URL
       expect(mockVideoElement.src).toBe(source);
-      expect(mockWaveSurferInstance.load).toHaveBeenCalledWith(source, peaks);
+      expect(mockWaveSurferInstance.load).toHaveBeenCalledWith(source, peaks, undefined);
 
       spy.mockRestore();
     });
@@ -795,9 +797,9 @@ describe('WaveSurferService', () => {
       
       // Load should not be called immediately since wavesurfer instance is null
       expect(mockWaveSurferInstance.load).not.toHaveBeenCalled();
-      
+
       // Should be stored as delayed load
-      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks });
+      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks, duration: undefined });
     });
 
     it('should set zoom level', () => {
@@ -1349,7 +1351,7 @@ describe('WaveSurferService', () => {
       expect(mockLoad).not.toHaveBeenCalled();
       
       // Should be stored as delayed load
-      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks });
+      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks, duration: undefined });
     });
 
     it('should process delayed load immediately when wavesurfer instance is created', async () => {
@@ -1365,16 +1367,16 @@ describe('WaveSurferService', () => {
       await wavesurferService.load(source, peaks);
       
       // Should be stored as delayed load
-      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks });
-      
+      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks, duration: undefined });
+
       // Now initialize wavesurfer - this should process the delayed load immediately
       wavesurferService.initialize(mockContainer, mockTimelineContainer);
-      
+
       // Wait a tick for async load to complete
       await new Promise(resolve => setTimeout(resolve, 0));
-      
+
       // The delayed load should be processed immediately after instance creation with signed URL
-      expect(mockLoad).toHaveBeenCalledWith('https://fake.s3.amazonaws.com/public/test.mp4', peaks);
+      expect(mockLoad).toHaveBeenCalledWith('https://fake.s3.amazonaws.com/public/test.mp4', peaks, undefined);
       expect(wavesurferService['_delayedLoad']).toBeNull();
     });
 
@@ -1392,7 +1394,7 @@ describe('WaveSurferService', () => {
       await wavesurferService.load(source, peaks);
       
       // Should use signed URL
-      expect(mockLoad).toHaveBeenCalledWith('https://fake.s3.amazonaws.com/public/test.mp4', peaks);
+      expect(mockLoad).toHaveBeenCalledWith('https://fake.s3.amazonaws.com/public/test.mp4', peaks, undefined);
       expect(wavesurferService['_delayedLoad']).toBeNull();
     });
 
@@ -1402,8 +1404,8 @@ describe('WaveSurferService', () => {
       const peaks = [1, 2, 3];
       await wavesurferService.load(source, peaks);
       
-      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks });
-      
+      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks, duration: undefined });
+
       // Destroy should clear it
       wavesurferService.destroy();
       
@@ -1461,16 +1463,16 @@ describe('WaveSurferService', () => {
       
       // Set up delayed load (service is not initialized yet)
       await wavesurferService.load(source, peaks);
-      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks });
-      
+      expect(wavesurferService['_delayedLoad']).toEqual({ source, peaks, duration: undefined });
+
       // Initialize with one set of containers
       wavesurferService.initialize(mockContainer, mockTimelineContainer);
-      
+
       // Wait a tick for async load to complete
       await new Promise(resolve => setTimeout(resolve, 0));
-      
+
       // Should have processed the delayed load immediately with signed URL
-      expect(mockLoad).toHaveBeenCalledWith('https://fake.s3.amazonaws.com/public/test.mp4', peaks);
+      expect(mockLoad).toHaveBeenCalledWith('https://fake.s3.amazonaws.com/public/test.mp4', peaks, undefined);
       expect(wavesurferService['_delayedLoad']).toBeNull();
       
       // Now destroy the instance and set up a new delayed load to test preservation
@@ -1479,7 +1481,7 @@ describe('WaveSurferService', () => {
       const source2 = 'https://bucket.s3.amazonaws.com/public/test2.mp4';
       const peaks2 = [4, 5, 6];
       await wavesurferService.load(source2, peaks2);
-      expect(wavesurferService['_delayedLoad']).toEqual({ source: source2, peaks: peaks2 });
+      expect(wavesurferService['_delayedLoad']).toEqual({ source: source2, peaks: peaks2, duration: undefined });
       
       // Initialize with different containers (including video element)
       const newContainer = document.createElement('div');
@@ -1489,7 +1491,7 @@ describe('WaveSurferService', () => {
       await new Promise(resolve => setTimeout(resolve, 0));
       
       // Should process the delayed load with the new containers with signed URL
-      expect(mockLoad).toHaveBeenCalledWith('https://fake.s3.amazonaws.com/public/test2.mp4', peaks2);
+      expect(mockLoad).toHaveBeenCalledWith('https://fake.s3.amazonaws.com/public/test2.mp4', peaks2, undefined);
       expect(wavesurferService['_delayedLoad']).toBeNull();
     });
   });

--- a/src/services/wavesurferService.ts
+++ b/src/services/wavesurferService.ts
@@ -22,6 +22,7 @@ interface RegionEvent {
 interface DelayedLoad {
   source: string;
   peaks: unknown;
+  duration?: number;
 }
 
 // Type for regions plugin instance
@@ -55,6 +56,7 @@ class WaveSurferService {
   private _isAddingSubscriptionRegion: boolean = false
   private _canEdit: boolean = false
   private _disableDragSelection: (() => void) | null = null
+  private _peaksDuration: number | null = null
 
   private REGION_BACKGROUND_COLOR = 'rgba(0, 0, 0, 0.1)'
   private REGION_HIGHLIGHTED_COLOR = 'rgba(0, 213, 255, 0.1)'
@@ -151,7 +153,7 @@ class WaveSurferService {
 
     // If we have a delayed load waiting, process it immediately after creation
     if (this._delayedLoad) {
-      this.load(this._delayedLoad.source, this._delayedLoad.peaks);
+      this.load(this._delayedLoad.source, this._delayedLoad.peaks, this._delayedLoad.duration);
       this._delayedLoad = null;
     }
 
@@ -166,7 +168,7 @@ class WaveSurferService {
       this.ready = true
       
       if (this._delayedLoad !== null) {
-        this.load(this._delayedLoad.source, this._delayedLoad.peaks);
+        this.load(this._delayedLoad.source, this._delayedLoad.peaks, this._delayedLoad.duration);
         this._delayedLoad = null;
       }
       
@@ -358,34 +360,35 @@ class WaveSurferService {
   }
 
   // Set a new source URL and peaks data
-  async load(source: string, peaks: unknown): Promise<void> {
+  async load(source: string, peaks: unknown, duration?: number): Promise<void> {
     if (!this.wavesurfer) {
-      this._delayedLoad = { source, peaks };
+      this._delayedLoad = { source, peaks, duration };
       return;
     }
-    
+
+    if (duration != null) {
+      this._peaksDuration = duration;
+    }
+
     try {
       let signedMediaUrl: string;
-      
+
       if (this.currentMediaElement) {
-        // If we have a media element, we need to set the src attribute to the signed URL
-        // and then load peaks only in wavesurfer
         signedMediaUrl = await generateSignedUrl(source);
         this.currentMediaElement.src = signedMediaUrl;
-        this.wavesurfer?.load(signedMediaUrl, peaks as (Float32Array)[]);
+        this.wavesurfer?.load(signedMediaUrl, peaks as (Float32Array)[], duration);
       } else {
-        // For audio-only, load the signed media source directly.
         signedMediaUrl = await generateSignedUrl(source);
-        this.wavesurfer?.load(signedMediaUrl, peaks as (Float32Array)[]);
+        this.wavesurfer?.load(signedMediaUrl, peaks as (Float32Array)[], duration);
       }
     } catch (error) {
       console.error('Failed to load media with signed URL:', error);
       // Fallback to original URL if signing fails
       if (this.currentMediaElement) {
         this.currentMediaElement.src = source;
-        this.wavesurfer?.load(source, peaks as (Float32Array)[]);
+        this.wavesurfer?.load(source, peaks as (Float32Array)[], duration);
       } else {
-        this.wavesurfer?.load(source, peaks as (Float32Array)[]);
+        this.wavesurfer?.load(source, peaks as (Float32Array)[], duration);
       }
     }
   }
@@ -411,12 +414,13 @@ class WaveSurferService {
     try {
       // Generate fresh signed URL
       const signedMediaUrl = await generateSignedUrl(source);
-      
+      const duration = this._peaksDuration ?? undefined;
+
       if (this.currentMediaElement) {
         this.currentMediaElement.src = signedMediaUrl;
-        this.wavesurfer.load(signedMediaUrl, peaks as (Float32Array)[]);
+        this.wavesurfer.load(signedMediaUrl, peaks as (Float32Array)[], duration);
       } else {
-        this.wavesurfer.load(signedMediaUrl, peaks as (Float32Array)[]);
+        this.wavesurfer.load(signedMediaUrl, peaks as (Float32Array)[], duration);
       }
 
       // Wait for ready event before seeking
@@ -765,6 +769,7 @@ class WaveSurferService {
     this._inboundRegionCurrentHighlighted = null;
     this._playbackBoundRegion = null;
     this._disableDragSelection = null;
+    this._peaksDuration = null;
     this.muteEvents = false;
     this.clearAllListeners();
   }

--- a/src/stores/useEditorStore.ts
+++ b/src/stores/useEditorStore.ts
@@ -91,6 +91,7 @@ interface EditorState {
   setTranscription: (transcription: TranscriptionData) => void;
   setSaved: (saved: boolean) => void;
   setSaveStatus: (status: 'saved' | 'saving' | 'pending' | 'error') => void;
+  setPeaks: (peaks: number[]) => void;
 
   // Region actions
   setSelectedRegion: (regionId: string | null) => void;
@@ -337,6 +338,10 @@ export const useEditorStore = create<EditorState>()(
 
       setCanEdit: (canEdit: boolean) => {
         set({ canEdit });
+      },
+
+      setPeaks: (peaks: number[]) => {
+        set({ peaks });
       },
 
       cleanup: () => {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -114,6 +114,7 @@ export interface PendingSave<T> {
 export type LoadTranscriptionResult = {
   transcription: TranscriptionModel;
   peaks: number[];
+  peaksDuration: number;
   regions: RegionModel[];
   issues: IssueData[];
   comments: CommentData[];

--- a/src/use-cases/load-transcription.test.ts
+++ b/src/use-cases/load-transcription.test.ts
@@ -46,6 +46,7 @@ describe('LoadTranscription', () => {
       source: 'test-audio.mp3',
     },
     peaks: [0.1, 0.2, 0.3, 0.4],
+    peaksDuration: 21.7,
     regions: [
       { id: 'region-1', start: 10, end: 20 },
       { id: 'region-2', start: 25, end: 35 },
@@ -214,7 +215,8 @@ describe('LoadTranscription', () => {
       
       expect(services.wavesurferService.load).toHaveBeenCalledWith(
         mockTranscriptionData.transcription.source,
-        mockTranscriptionData.peaks
+        mockTranscriptionData.peaks,
+        mockTranscriptionData.peaksDuration
       );
     });
 
@@ -307,7 +309,8 @@ describe('LoadTranscription', () => {
         
         expect(services.wavesurferService.load).toHaveBeenCalledWith(
           mockTranscriptionData.transcription.source,
-          undefined
+          undefined,
+          mockTranscriptionData.peaksDuration
         );
       });
 
@@ -341,7 +344,7 @@ describe('LoadTranscription', () => {
         
         await useCase.execute();
         
-        expect(services.wavesurferService.load).toHaveBeenCalledWith('test-audio.wav', mockTranscriptionData.peaks);
+        expect(services.wavesurferService.load).toHaveBeenCalledWith('test-audio.wav', mockTranscriptionData.peaks, mockTranscriptionData.peaksDuration);
       });
 
       it('should handle complete successful flow', async () => {

--- a/src/use-cases/load-transcription.ts
+++ b/src/use-cases/load-transcription.ts
@@ -69,7 +69,7 @@ export class LoadTranscription {
     }
 
     // load wavesurfer details _outside_ the React system
-    await wavesurferService.load(data.transcription.source, data.peaks)
+    await wavesurferService.load(data.transcription.source, data.peaks, data.peaksDuration)
     wavesurferService.setRegions(data.regions)
     
     // If we have a selected region, seek to it in the wavesurfer and apply styling


### PR DESCRIPTION
Improves how waveform peaks are generated and processed to reduce the risk of sync issues with non-standard audio files, and adds tooling for users to recover from bad peaks files.

Also upgrades WaveSurfer from 7.9.5 to 7.12.7.

Note: waveform desync is not fully resolved by this PR. A future project to transcode all uploads to a standard format at upload time is the intended permanent fix.
  
## Testing

Updated unit tests across the Lambda, wavesurfer service, transcription service, and load-transcription. Manually tested the regenerate button with a problematic MP3.