### PR TITLE
Add deployment slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,27 @@ A docker image is provided to build C bindings if needed. Currently needed when 
 brew install --cask docker
 ```
 
+## Setup Slack Deploy Notifications
+
+**One-time setup per environment** :
+
+```bash
+aws ssm put-parameter \
+  --name /kiyanaw/slack/staging/deploy-webhook-url \
+  --type SecureString \
+  --value 'https://hooks.slack.com/services/YOUR/WEBHOOK/URL' \
+  --profile <your-staging-aws-profile> --region us-east-1
+
+# Repeat for production:
+aws ssm put-parameter \
+  --name /kiyanaw/slack/production/deploy-webhook-url \
+  --type SecureString \
+  --value 'https://hooks.slack.com/services/YOUR/WEBHOOK/URL' \
+  --profile <your-production-aws-profile> --region us-east-1
+```
+
+Notifications are optional and will show a warning if not configured.
+
 ## Setup Spellcheck API Credentials
 
 The spellcheck API requires a key that is environment-specific. After pulling an environment, run:

--- a/amplify/hooks/lib/deploy-context.js
+++ b/amplify/hooks/lib/deploy-context.js
@@ -1,0 +1,59 @@
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+export const projectRoot = path.resolve(__dirname, '..', '..', '..');
+
+function readJsonFile(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+export function getAmplifyEnv() {
+  const localEnvInfo = readJsonFile(path.join(projectRoot, 'amplify', '.config', 'local-env-info.json'));
+  const envName = localEnvInfo.envName;
+  const localAwsInfo = readJsonFile(path.join(projectRoot, 'amplify', '.config', 'local-aws-info.json'));
+  const awsProfile = localAwsInfo[envName]?.profileName || 'default';
+  return { envName, awsProfile };
+}
+
+export function getGitContext() {
+  const run = (cmd) => execSync(cmd, { encoding: 'utf8', cwd: projectRoot }).trim();
+  return {
+    sha: run('git rev-parse --short HEAD'),
+    branch: run('git rev-parse --abbrev-ref HEAD'),
+    commitSubject: run('git log -1 --pretty=%s'),
+  };
+}
+
+export function getSystemContext() {
+  return {
+    user: os.userInfo().username,
+    host: os.hostname(),
+  };
+}
+
+function startFilePath(envName) {
+  return path.join(os.tmpdir(), `kiyanaw-deploy-start-${envName}.json`);
+}
+
+export function writeStartFile(envName, data) {
+  writeFileSync(startFilePath(envName), JSON.stringify(data));
+}
+
+export function readStartFile(envName) {
+  try {
+    return JSON.parse(readFileSync(startFilePath(envName), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function deleteStartFile(envName) {
+  try {
+    unlinkSync(startFilePath(envName));
+  } catch {}
+}

--- a/amplify/hooks/lib/deploy-context.js
+++ b/amplify/hooks/lib/deploy-context.js
@@ -25,15 +25,12 @@ export function getGitContext() {
   return {
     sha: run('git rev-parse --short HEAD'),
     branch: run('git rev-parse --abbrev-ref HEAD'),
-    commitSubject: run('git log -1 --pretty=%s'),
+    gitUser: run('git config user.name'),
   };
 }
 
 export function getSystemContext() {
-  return {
-    user: os.userInfo().username,
-    host: os.hostname(),
-  };
+  return { gitUser: os.userInfo().username };
 }
 
 function startFilePath(envName) {

--- a/amplify/hooks/lib/deploy-context.js
+++ b/amplify/hooks/lib/deploy-context.js
@@ -29,10 +29,6 @@ export function getGitContext() {
   };
 }
 
-export function getSystemContext() {
-  return { gitUser: os.userInfo().username };
-}
-
 function startFilePath(envName) {
   return path.join(os.tmpdir(), `kiyanaw-deploy-start-${envName}.json`);
 }

--- a/amplify/hooks/lib/slack.js
+++ b/amplify/hooks/lib/slack.js
@@ -1,0 +1,71 @@
+import { execSync } from 'child_process';
+import https from 'https';
+
+export function getWebhookUrl(awsProfile, envName) {
+  try {
+    const url = execSync(
+      `aws ssm get-parameter --name /kiyanaw/slack/${envName}/deploy-webhook-url --with-decryption --query 'Parameter.Value' --output text --profile ${awsProfile} --region us-east-1`,
+      { encoding: 'utf8' }
+    ).trim();
+    return url && url !== 'None' ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+export function postToSlack(webhookUrl, text) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ text });
+    const url = new URL(webhookUrl);
+    const req = https.request(
+      {
+        hostname: url.hostname,
+        path: url.pathname + url.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        res.resume();
+        res.on('end', resolve);
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function formatDuration(ms) {
+  const totalSecs = Math.round(ms / 1000);
+  const mins = Math.floor(totalSecs / 60);
+  const secs = totalSecs % 60;
+  return mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+}
+
+export function buildStartMessage({ envName, lifecycle, user, host, branch, sha, commitSubject }) {
+  return [
+    `:rocket: *Deployment started* — kiyânaw Transcribe (\`${envName}\`)`,
+    `*Lifecycle:* ${lifecycle}`,
+    `*Triggered by:* ${user}@${host}`,
+    `*Branch:* ${branch} @ \`${sha}\``,
+    `*Commit:* ${commitSubject}`,
+  ].join('\n');
+}
+
+export function buildFinishMessage({ envName, lifecycle, user, host, branch, sha, success, stage, error, durationMs }) {
+  const icon = success ? ':white_check_mark:' : ':x:';
+  const status = success ? 'succeeded' : 'failed';
+  const lines = [
+    `${icon} *Deployment ${status}* — kiyânaw Transcribe (\`${envName}\`)`,
+    `*Lifecycle:* ${lifecycle}`,
+    `*Triggered by:* ${user}@${host}`,
+    `*Branch:* ${branch} @ \`${sha}\``,
+  ];
+  if (durationMs != null) lines.push(`*Duration:* ${formatDuration(durationMs)}`);
+  if (!success && stage) lines.push(`*Stage:* ${stage}`);
+  if (!success && error) lines.push(`*Error:* \`\`\`${String(error).slice(0, 500)}\`\`\``);
+  return lines.join('\n');
+}

--- a/amplify/hooks/lib/slack.js
+++ b/amplify/hooks/lib/slack.js
@@ -45,23 +45,22 @@ function formatDuration(ms) {
   return mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
 }
 
-export function buildStartMessage({ envName, lifecycle, user, host, branch, sha, commitSubject }) {
+export function buildStartMessage({ envName, lifecycle, gitUser, branch, sha }) {
   return [
-    `:rocket: *Deployment started* — kiyânaw Transcribe (\`${envName}\`)`,
+    `:rocket: *Deployment started* for \`${envName}\``,
     `*Lifecycle:* ${lifecycle}`,
-    `*Triggered by:* ${user}@${host}`,
+    `*Triggered by:* ${gitUser}`,
     `*Branch:* ${branch} @ \`${sha}\``,
-    `*Commit:* ${commitSubject}`,
   ].join('\n');
 }
 
-export function buildFinishMessage({ envName, lifecycle, user, host, branch, sha, success, stage, error, durationMs }) {
+export function buildFinishMessage({ envName, lifecycle, gitUser, branch, sha, success, stage, error, durationMs }) {
   const icon = success ? ':white_check_mark:' : ':x:';
   const status = success ? 'succeeded' : 'failed';
   const lines = [
-    `${icon} *Deployment ${status}* — kiyânaw Transcribe (\`${envName}\`)`,
+    `${icon} *Deployment ${status}* for \`${envName}\``,
     `*Lifecycle:* ${lifecycle}`,
-    `*Triggered by:* ${user}@${host}`,
+    `*Triggered by:* ${gitUser}`,
     `*Branch:* ${branch} @ \`${sha}\``,
   ];
   if (durationMs != null) lines.push(`*Duration:* ${formatDuration(durationMs)}`);

--- a/amplify/hooks/post-publish.js
+++ b/amplify/hooks/post-publish.js
@@ -16,33 +16,45 @@
 import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { getAmplifyEnv, getGitContext, getSystemContext, projectRoot, readStartFile, deleteStartFile } from './lib/deploy-context.js';
+import { getWebhookUrl, postToSlack, buildFinishMessage } from './lib/slack.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Read hook input from stdin
 let input = '';
 process.stdin.on('data', (chunk) => {
   input += chunk;
 });
 
-process.stdin.on('end', () => {
+process.stdin.on('end', async () => {
+  const notifyFinish = async ({ success, stage = null, error = null }) => {
+    try {
+      const { envName, awsProfile } = getAmplifyEnv();
+      const webhookUrl = getWebhookUrl(awsProfile, envName);
+      if (!webhookUrl) return;
+      const startData = readStartFile(envName);
+      const durationMs = startData ? Date.now() - startData.startedAt : null;
+      const ctx = startData ?? { lifecycle: 'publish', ...getGitContext(), ...getSystemContext() };
+      await postToSlack(
+        webhookUrl,
+        buildFinishMessage({ ...ctx, envName, success, stage, error, durationMs })
+      );
+      deleteStartFile(envName);
+    } catch (notifyErr) {
+      console.warn('Warning: Slack finish notification failed:', notifyErr.message);
+    }
+  };
+
   try {
     const hookData = JSON.parse(input);
 
-    // Check if the publish was successful
     if (hookData.error) {
       console.log('Amplify publish encountered an error. Skipping Serverless deployment.');
+      await notifyFinish({ success: false, stage: 'amplify publish', error: String(hookData.error) });
       process.exit(0);
     }
 
     console.log('\n========================================');
     console.log('🚀 Post-Publish Hook: Deploying Serverless Infrastructure');
     console.log('========================================\n');
-
-    // Get the project root (two levels up from amplify/hooks/)
-    const projectRoot = path.resolve(__dirname, '..', '..');
 
     // Sync Amplify environment context
     console.log('📋 Syncing Amplify environment context...');
@@ -67,15 +79,26 @@ process.stdin.on('end', () => {
     console.log('');
 
     // Deploy Serverless stack
-    console.log('📦 Deploying Serverless stack...\n');
-    execSync('npx serverless deploy', {
-      cwd: projectRoot,
-      stdio: 'inherit',
-    });
+    let deploySuccess = true;
+    let failedStage = null;
+    let failedError = null;
 
-    console.log('\n========================================');
-    console.log('✅ Serverless deployment completed successfully!');
-    console.log('========================================\n');
+    console.log('📦 Deploying Serverless stack...\n');
+    try {
+      execSync('npx serverless deploy', {
+        cwd: projectRoot,
+        stdio: 'inherit',
+      });
+      console.log('\n========================================');
+      console.log('✅ Serverless deployment completed successfully!');
+      console.log('========================================\n');
+    } catch (slsError) {
+      deploySuccess = false;
+      failedStage = 'serverless deploy';
+      failedError = slsError.message;
+      console.error('\n❌ Serverless deployment failed:', slsError.message);
+      console.error('You may need to manually run: npm run serverless:deploy\n');
+    }
 
     // Attach VPC and EFS to Lambda functions
     console.log('🔗 Attaching VPC and EFS to Lambda functions...\n');
@@ -86,7 +109,7 @@ process.stdin.on('end', () => {
       });
     } catch (attachError) {
       console.warn('\n⚠ Warning: Could not attach VPC/EFS to Lambda functions.');
-      console.warn('This is normal if the Lambdas are being updated or don\'t exist yet.');
+      console.warn("This is normal if the Lambdas are being updated or don't exist yet.");
       console.warn('You can manually run: node scripts/serverless/attach-lambda-vpc-efs.js\n');
     }
 
@@ -98,15 +121,22 @@ process.stdin.on('end', () => {
         stdio: 'inherit',
       });
     } catch (cfError) {
+      if (deploySuccess) {
+        deploySuccess = false;
+        failedStage = 'cloudfront invalidation';
+        failedError = cfError.message;
+      }
       console.warn('\n⚠ Warning: CloudFront invalidation failed.');
       console.warn('You can manually run: node scripts/serverless/invalidate-cloudfront.js\n');
     }
 
+    await notifyFinish({ success: deploySuccess, stage: failedStage, error: failedError });
     process.exit(0);
   } catch (error) {
     console.error('\n❌ Error in post-publish hook:', error.message);
     console.error('\nServerless deployment failed. Your Amplify changes were deployed successfully,');
     console.error('but you may need to manually run: npm run serverless:deploy\n');
+    await notifyFinish({ success: false, stage: 'serverless deploy', error: error.message });
 
     // Exit with 0 to not block the Amplify CLI
     // Change to process.exit(1) if you want to fail the entire publish on Serverless errors

--- a/amplify/hooks/post-publish.js
+++ b/amplify/hooks/post-publish.js
@@ -16,7 +16,7 @@
 import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import path from 'path';
-import { getAmplifyEnv, getGitContext, getSystemContext, projectRoot, readStartFile, deleteStartFile } from './lib/deploy-context.js';
+import { getAmplifyEnv, getGitContext, projectRoot, readStartFile, deleteStartFile } from './lib/deploy-context.js';
 import { getWebhookUrl, postToSlack, buildFinishMessage } from './lib/slack.js';
 
 let input = '';
@@ -32,7 +32,7 @@ process.stdin.on('end', async () => {
       if (!webhookUrl) return;
       const startData = readStartFile(envName);
       const durationMs = startData ? Date.now() - startData.startedAt : null;
-      const ctx = startData ?? { lifecycle: 'publish', ...getGitContext(), ...getSystemContext() };
+      const ctx = startData ?? { lifecycle: 'publish', ...getGitContext() };
       await postToSlack(
         webhookUrl,
         buildFinishMessage({ ...ctx, envName, success, stage, error, durationMs })

--- a/amplify/hooks/post-push.js
+++ b/amplify/hooks/post-push.js
@@ -13,33 +13,50 @@
 import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { getAmplifyEnv, getGitContext, getSystemContext, projectRoot, readStartFile, deleteStartFile } from './lib/deploy-context.js';
+import { getWebhookUrl, postToSlack, buildFinishMessage } from './lib/slack.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Read hook input from stdin
 let input = '';
 process.stdin.on('data', (chunk) => {
   input += chunk;
 });
 
-process.stdin.on('end', () => {
+process.stdin.on('end', async () => {
+  let isPublish = false;
+
+  const notifyFinish = async ({ success, stage = null, error = null }) => {
+    // post-publish.js sends the finish notification for amplify publish runs
+    if (isPublish) return;
+    try {
+      const { envName, awsProfile } = getAmplifyEnv();
+      const webhookUrl = getWebhookUrl(awsProfile, envName);
+      if (!webhookUrl) return;
+      const startData = readStartFile(envName);
+      const durationMs = startData ? Date.now() - startData.startedAt : null;
+      const ctx = startData ?? { lifecycle: 'push', ...getGitContext(), ...getSystemContext() };
+      await postToSlack(
+        webhookUrl,
+        buildFinishMessage({ ...ctx, envName, success, stage, error, durationMs })
+      );
+      deleteStartFile(envName);
+    } catch (notifyErr) {
+      console.warn('Warning: Slack finish notification failed:', notifyErr.message);
+    }
+  };
+
   try {
     const hookData = JSON.parse(input);
+    isPublish = hookData.data?.amplify?.command === 'publish';
 
-    // Check if the push was successful
     if (hookData.error) {
       console.log('Amplify push encountered an error. Skipping Serverless deployment.');
+      await notifyFinish({ success: false, stage: 'amplify push', error: String(hookData.error) });
       process.exit(0);
     }
 
     console.log('\n========================================');
     console.log('🚀 Post-Push Hook: Deploying Serverless Infrastructure');
     console.log('========================================\n');
-
-    // Get the project root (two levels up from amplify/hooks/)
-    const projectRoot = path.resolve(__dirname, '..', '..');
 
     // Sync Amplify environment context
     console.log('📋 Syncing Amplify environment context...');
@@ -83,15 +100,17 @@ process.stdin.on('end', () => {
       });
     } catch (attachError) {
       console.warn('\n⚠ Warning: Could not attach VPC/EFS to Lambda functions.');
-      console.warn('This is normal if the Lambdas are being updated or don\'t exist yet.');
+      console.warn("This is normal if the Lambdas are being updated or don't exist yet.");
       console.warn('You can manually run: node scripts/serverless/attach-lambda-vpc-efs.js\n');
     }
 
+    await notifyFinish({ success: true });
     process.exit(0);
   } catch (error) {
     console.error('\n❌ Error in post-push hook:', error.message);
     console.error('\nServerless deployment failed. Your Amplify changes were deployed successfully,');
     console.error('but you may need to manually run: npm run serverless:deploy\n');
+    await notifyFinish({ success: false, stage: 'serverless deploy', error: error.message });
 
     // Exit with 0 to not block the Amplify CLI
     // Change to process.exit(1) if you want to fail the entire push on Serverless errors

--- a/amplify/hooks/post-push.js
+++ b/amplify/hooks/post-push.js
@@ -13,7 +13,7 @@
 import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import path from 'path';
-import { getAmplifyEnv, getGitContext, getSystemContext, projectRoot, readStartFile, deleteStartFile } from './lib/deploy-context.js';
+import { getAmplifyEnv, getGitContext, projectRoot, readStartFile, deleteStartFile } from './lib/deploy-context.js';
 import { getWebhookUrl, postToSlack, buildFinishMessage } from './lib/slack.js';
 
 let input = '';
@@ -33,7 +33,7 @@ process.stdin.on('end', async () => {
       if (!webhookUrl) return;
       const startData = readStartFile(envName);
       const durationMs = startData ? Date.now() - startData.startedAt : null;
-      const ctx = startData ?? { lifecycle: 'push', ...getGitContext(), ...getSystemContext() };
+      const ctx = startData ?? { lifecycle: 'push', ...getGitContext() };
       await postToSlack(
         webhookUrl,
         buildFinishMessage({ ...ctx, envName, success, stage, error, durationMs })

--- a/amplify/hooks/pre-publish.js
+++ b/amplify/hooks/pre-publish.js
@@ -3,9 +3,10 @@
 /**
  * Amplify Pre-Publish Hook
  *
- * Before `amplify publish` builds the frontend, this hook fetches the spellcheck
- * API key from API Gateway and writes VITE_SPELLCHECK_API_BASE_URL and
- * VITE_SPELLCHECK_API_KEY to .env.local so Vite bakes them into the build.
+ * Before `amplify publish` builds the frontend, this hook:
+ *   1. Sends a deploy-start notification to Slack and records a timestamp for duration tracking.
+ *   2. Fetches the spellcheck API key from API Gateway and writes VITE_SPELLCHECK_API_BASE_URL
+ *      and VITE_SPELLCHECK_API_KEY to .env.local so Vite bakes them into the build.
  *
  * The API key is looked up by name: transcribe-<envName> (e.g. transcribe-staging)
  * Base URL is derived from the env: staging → api.kiyanaw.dev, production → api.kiyanaw.net
@@ -14,12 +15,8 @@
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const projectRoot = path.resolve(__dirname, '..', '..');
+import { getAmplifyEnv, getGitContext, getSystemContext, writeStartFile, projectRoot } from './lib/deploy-context.js';
+import { getWebhookUrl, postToSlack, buildStartMessage } from './lib/slack.js';
 
 function readJsonFile(filePath) {
   return JSON.parse(readFileSync(filePath, 'utf8'));
@@ -36,13 +33,30 @@ process.stdin.on('data', (chunk) => {
   input += chunk;
 });
 
-process.stdin.on('end', () => {
+process.stdin.on('end', async () => {
   try {
     const hookData = JSON.parse(input);
 
     if (hookData.error) {
       console.log('Amplify encountered an error before pre-publish. Skipping spellcheck env setup.');
       process.exit(0);
+    }
+
+    // Send deploy start notification and record timestamp for duration tracking
+    try {
+      const { envName, awsProfile } = getAmplifyEnv();
+      const git = getGitContext();
+      const sys = getSystemContext();
+      const lifecycle = hookData.data?.amplify?.command ?? 'publish';
+      writeStartFile(envName, { startedAt: Date.now(), lifecycle, ...git, ...sys });
+      const webhookUrl = getWebhookUrl(awsProfile, envName);
+      if (webhookUrl) {
+        await postToSlack(webhookUrl, buildStartMessage({ envName, lifecycle, ...git, ...sys }));
+      } else {
+        console.log('Slack deploy-webhook not configured for this environment, skipping start notification.');
+      }
+    } catch (notifyErr) {
+      console.warn('Warning: Slack start notification failed:', notifyErr.message);
     }
 
     console.log('\n========================================');

--- a/amplify/hooks/pre-publish.js
+++ b/amplify/hooks/pre-publish.js
@@ -15,7 +15,7 @@
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
-import { getAmplifyEnv, getGitContext, getSystemContext, writeStartFile, projectRoot } from './lib/deploy-context.js';
+import { getAmplifyEnv, getGitContext, writeStartFile, projectRoot } from './lib/deploy-context.js';
 import { getWebhookUrl, postToSlack, buildStartMessage } from './lib/slack.js';
 
 function readJsonFile(filePath) {
@@ -46,12 +46,11 @@ process.stdin.on('end', async () => {
     try {
       const { envName, awsProfile } = getAmplifyEnv();
       const git = getGitContext();
-      const sys = getSystemContext();
       const lifecycle = hookData.data?.amplify?.command ?? 'publish';
-      writeStartFile(envName, { startedAt: Date.now(), lifecycle, ...git, ...sys });
+      writeStartFile(envName, { startedAt: Date.now(), lifecycle, ...git });
       const webhookUrl = getWebhookUrl(awsProfile, envName);
       if (webhookUrl) {
-        await postToSlack(webhookUrl, buildStartMessage({ envName, lifecycle, ...git, ...sys }));
+        await postToSlack(webhookUrl, buildStartMessage({ envName, lifecycle, ...git }));
       } else {
         console.log('Slack deploy-webhook not configured for this environment, skipping start notification.');
       }

--- a/amplify/hooks/pre-push.js
+++ b/amplify/hooks/pre-push.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+/**
+ * Amplify Pre-Push Hook
+ *
+ * Fires before both `amplify push` and `amplify publish`. Sends a "deployment
+ * started" notification to Slack and writes a timestamp file so post-hooks can
+ * compute duration.
+ *
+ * To skip this hook, use: amplify push --no-hooks
+ */
+
+import { getAmplifyEnv, getGitContext, getSystemContext, writeStartFile } from './lib/deploy-context.js';
+import { getWebhookUrl, postToSlack, buildStartMessage } from './lib/slack.js';
+
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+
+process.stdin.on('end', async () => {
+  try {
+    const hookData = JSON.parse(input);
+    if (hookData.error) {
+      process.exit(0);
+    }
+
+    const { envName, awsProfile } = getAmplifyEnv();
+    const lifecycle = hookData.data?.amplify?.command ?? 'push';
+    const git = getGitContext();
+    const sys = getSystemContext();
+
+    writeStartFile(envName, { startedAt: Date.now(), lifecycle, ...git, ...sys });
+
+    const webhookUrl = getWebhookUrl(awsProfile, envName);
+    if (!webhookUrl) {
+      console.log('Slack deploy-webhook not configured for this environment, skipping start notification.');
+      process.exit(0);
+    }
+
+    await postToSlack(webhookUrl, buildStartMessage({ envName, lifecycle, ...git, ...sys }));
+  } catch (err) {
+    console.warn('Warning: Slack start notification failed:', err.message);
+  }
+
+  process.exit(0);
+});

--- a/amplify/hooks/pre-push.js
+++ b/amplify/hooks/pre-push.js
@@ -10,7 +10,7 @@
  * To skip this hook, use: amplify push --no-hooks
  */
 
-import { getAmplifyEnv, getGitContext, getSystemContext, writeStartFile } from './lib/deploy-context.js';
+import { getAmplifyEnv, getGitContext, writeStartFile } from './lib/deploy-context.js';
 import { getWebhookUrl, postToSlack, buildStartMessage } from './lib/slack.js';
 
 let input = '';
@@ -28,9 +28,8 @@ process.stdin.on('end', async () => {
     const { envName, awsProfile } = getAmplifyEnv();
     const lifecycle = hookData.data?.amplify?.command ?? 'push';
     const git = getGitContext();
-    const sys = getSystemContext();
 
-    writeStartFile(envName, { startedAt: Date.now(), lifecycle, ...git, ...sys });
+    writeStartFile(envName, { startedAt: Date.now(), lifecycle, ...git });
 
     const webhookUrl = getWebhookUrl(awsProfile, envName);
     if (!webhookUrl) {
@@ -38,7 +37,7 @@ process.stdin.on('end', async () => {
       process.exit(0);
     }
 
-    await postToSlack(webhookUrl, buildStartMessage({ envName, lifecycle, ...git, ...sys }));
+    await postToSlack(webhookUrl, buildStartMessage({ envName, lifecycle, ...git }));
   } catch (err) {
     console.warn('Warning: Slack start notification failed:', err.message);
   }


### PR DESCRIPTION
Adds Slack notification support for both push and publish deployments. Setting up your own Slack app and providing a webhook URL enable the notifications.


### Testing

Did both new pushes and publishes from this branch and saw notifications in our builds channel
Tested a broken deploy to see failure notification