### PR TITLE
Fix region autoplay after wavesurfer update

### DIFF
--- a/src/hooks/useWavesurferEvents.test.ts
+++ b/src/hooks/useWavesurferEvents.test.ts
@@ -448,6 +448,38 @@ describe('useWavesurferEvents', () => {
       expect(mockScrollElementIntoView).toHaveBeenCalledWith(`div#regionitem-${regionId}`);
     });
 
+    it('should update selected region in store when region-in event fires', () => {
+      const transcriptionId = 'test-transcription-1';
+      const regionId = 'test-region-1';
+
+      renderHook(() => useWavesurferEvents(transcriptionId));
+
+      const regionInHandler = mockOn.mock.calls.find(call => call[0] === 'region-in')[1];
+      regionInHandler({ regionId });
+
+      expect(mockStore.setSelectedRegion).toHaveBeenCalledWith(regionId);
+    });
+
+    it('should update selected region when audio playback enters a new region', () => {
+      const transcriptionId = 'test-transcription-1';
+      const firstRegionId = 'region-A';
+      const secondRegionId = 'region-B';
+
+      mockAddCustomStyle
+        .mockReturnValueOnce('style-A')
+        .mockReturnValueOnce('style-B');
+
+      renderHook(() => useWavesurferEvents(transcriptionId));
+
+      const regionInHandler = mockOn.mock.calls.find(call => call[0] === 'region-in')[1];
+
+      regionInHandler({ regionId: firstRegionId });
+      expect(mockStore.setSelectedRegion).toHaveBeenCalledWith(firstRegionId);
+
+      regionInHandler({ regionId: secondRegionId });
+      expect(mockStore.setSelectedRegion).toHaveBeenLastCalledWith(secondRegionId);
+    });
+
     it('should both highlight and scroll region when region-in event fires', () => {
       const transcriptionId = 'test-transcription-1';
       const regionId = 'test-region-456';

--- a/src/hooks/useWavesurferEvents.ts
+++ b/src/hooks/useWavesurferEvents.ts
@@ -111,6 +111,8 @@ export const useWavesurferEvents = (transcriptionId: string, source?: string): v
     const handleRegionIn = (data: unknown) => {
       const { regionId } = data as RegionEvent;
 
+      useEditorStore.getState().setSelectedRegion(regionId);
+
       if (highlightedInboundRegionRef.current) {
         const previousStyleId = styleIdRef.current.get(highlightedInboundRegionRef.current);
         if (previousStyleId) {

--- a/src/services/wavesurferService.test.ts
+++ b/src/services/wavesurferService.test.ts
@@ -693,19 +693,39 @@ describe('WaveSurferService', () => {
       expect(mockWaveSurferInstance.play).toHaveBeenCalled();
     });
 
-    it('should retry play once when browser rejects with AbortError', async () => {
-      const abortError = new DOMException('The play() request was interrupted', 'AbortError');
-      mockWaveSurferInstance.play = jest.fn()
-        .mockRejectedValueOnce(abortError)
-        .mockResolvedValueOnce(undefined);
+    it('should wait for seek to complete before playing when media is seeking', async () => {
+      let seekedCallback: (() => void) | null = null;
+      const mockMediaElement = {
+        seeking: true,
+        addEventListener: jest.fn().mockImplementation((event: string, cb: () => void) => {
+          if (event === 'seeked') {
+            seekedCallback = cb;
+          }
+        }),
+      };
+      mockWaveSurferInstance.getMediaElement.mockReturnValue(mockMediaElement);
+      mockWaveSurferInstance.play = jest.fn().mockResolvedValue(undefined);
 
-      jest.useFakeTimers();
       const playPromise = wavesurferService.play();
-      await jest.runAllTimersAsync();
+
+      // play() should not have been called yet — still waiting for seeked
+      expect(mockWaveSurferInstance.play).not.toHaveBeenCalled();
+
+      // Resolve the seek
+      seekedCallback?.();
       await playPromise;
 
-      expect(mockWaveSurferInstance.play).toHaveBeenCalledTimes(2);
-      jest.useRealTimers();
+      expect(mockWaveSurferInstance.play).toHaveBeenCalledTimes(1);
+    });
+
+    it('should play immediately when media is not seeking', async () => {
+      const mockMediaElement = { seeking: false };
+      mockWaveSurferInstance.getMediaElement.mockReturnValue(mockMediaElement);
+      mockWaveSurferInstance.play = jest.fn().mockResolvedValue(undefined);
+
+      await wavesurferService.play();
+
+      expect(mockWaveSurferInstance.play).toHaveBeenCalledTimes(1);
     });
 
     it('should rethrow non-AbortError play failures', async () => {

--- a/src/services/wavesurferService.test.ts
+++ b/src/services/wavesurferService.test.ts
@@ -693,6 +693,29 @@ describe('WaveSurferService', () => {
       expect(mockWaveSurferInstance.play).toHaveBeenCalled();
     });
 
+    it('should retry play once when browser rejects with AbortError', async () => {
+      const abortError = new DOMException('The play() request was interrupted', 'AbortError');
+      mockWaveSurferInstance.play = jest.fn()
+        .mockRejectedValueOnce(abortError)
+        .mockResolvedValueOnce(undefined);
+
+      jest.useFakeTimers();
+      const playPromise = wavesurferService.play();
+      await jest.runAllTimersAsync();
+      await playPromise;
+
+      expect(mockWaveSurferInstance.play).toHaveBeenCalledTimes(2);
+      jest.useRealTimers();
+    });
+
+    it('should rethrow non-AbortError play failures', async () => {
+      const networkError = new Error('Network error');
+      mockWaveSurferInstance.play = jest.fn().mockRejectedValue(networkError);
+
+      await expect(wavesurferService.play()).rejects.toThrow('Network error');
+      expect(mockWaveSurferInstance.play).toHaveBeenCalledTimes(1);
+    });
+
     it('should not affect playback when playInFull is true but no bounded region exists', async () => {
       mockWaveSurferInstance.play = jest.fn().mockResolvedValue(undefined);
       

--- a/src/services/wavesurferService.ts
+++ b/src/services/wavesurferService.ts
@@ -547,17 +547,14 @@ class WaveSurferService {
       // Clear any region-bounded playback restrictions for full playback
       this.clearRegionBoundedPlayback();
     }
-    try {
-      await this.wavesurfer?.play();
-    } catch (error) {
-      if ((error as DOMException)?.name === 'AbortError') {
-        // Browser interrupted play() with a concurrent pause(); wait briefly and retry once
-        await new Promise<void>(resolve => setTimeout(resolve, 50));
-        await this.wavesurfer?.play();
-      } else {
-        throw error;
-      }
+    // If the media element is mid-seek, wait for it to finish before calling play().
+    // Calling media.play() while media.seeking=true causes an AbortError that WaveSurfer
+    // silently swallows (player.js catches it and returns undefined), leaving no audio playing.
+    const media = this.wavesurfer?.getMediaElement();
+    if (media?.seeking) {
+      await new Promise<void>(resolve => media.addEventListener('seeked', () => resolve(), { once: true }));
     }
+    await this.wavesurfer?.play();
   }
 
   pause(): void {

--- a/src/services/wavesurferService.ts
+++ b/src/services/wavesurferService.ts
@@ -547,7 +547,17 @@ class WaveSurferService {
       // Clear any region-bounded playback restrictions for full playback
       this.clearRegionBoundedPlayback();
     }
-    await this.wavesurfer?.play();
+    try {
+      await this.wavesurfer?.play();
+    } catch (error) {
+      if ((error as DOMException)?.name === 'AbortError') {
+        // Browser interrupted play() with a concurrent pause(); wait briefly and retry once
+        await new Promise<void>(resolve => setTimeout(resolve, 50));
+        await this.wavesurfer?.play();
+      } else {
+        throw error;
+      }
+    }
   }
 
   pause(): void {


### PR DESCRIPTION
Fixes region playback needing two clicks to actually start playing. Also fixes an unrelated region bug where the region play button didn't always respect that I new region had been selected (specifically when selecting it in the waveform).

If I had to guess when I updated the wavesurfer package it slightly changed the behavior.

### Testing

Added regression tests for the bugs that first failed and now pass
Deployed to staging and verified that region playback works in one click again.