### PR TITLE
Add Media table and access-controlled VTL resolvers

### DIFF
--- a/amplify/backend/api/kiyanaw/resolvers/Query.getMedia.req.vtl
+++ b/amplify/backend/api/kiyanaw/resolvers/Query.getMedia.req.vtl
@@ -1,0 +1,8 @@
+## Request mapping template for Query.getMedia
+{
+  "version": "2018-05-29",
+  "operation": "GetItem",
+  "key": {
+    "id": $util.dynamodb.toDynamoDBJson($ctx.arguments.id)
+  }
+}

--- a/amplify/backend/api/kiyanaw/resolvers/Query.getMedia.res.vtl
+++ b/amplify/backend/api/kiyanaw/resolvers/Query.getMedia.res.vtl
@@ -1,0 +1,50 @@
+## Response mapping template for Query.getMedia
+## Enforces owner/editor/viewer ACL on all media records
+
+#set($m = $ctx.result)
+#if($util.isNull($m))
+  $util.toJson(null)
+#else
+  #set($userSub = $ctx.identity.claims.get("sub"))
+  #set($userGroups = $ctx.identity.claims.get("cognito:groups"))
+
+  #if($util.isNull($userSub))
+    #set($userSub = "")
+  #end
+  #if($util.isNull($userGroups))
+    #set($userGroups = [])
+  #end
+
+  #set($hasAccess = false)
+
+  ## Owner
+  #if(!$util.isNull($m.owner) && $m.owner == $userSub)
+    #set($hasAccess = true)
+  #end
+
+  ## editors array
+  #if(!$util.isNull($m.editors) && $m.editors.contains($userSub))
+    #set($hasAccess = true)
+  #end
+
+  ## viewers array
+  #if(!$util.isNull($m.viewers) && $m.viewers.contains($userSub))
+    #set($hasAccess = true)
+  #end
+
+  ## editorGroups
+  #if(!$util.isNull($m.editorGroups) && $util.list.copyAndRetain($m.editorGroups, $userGroups).size() > 0)
+    #set($hasAccess = true)
+  #end
+
+  ## viewerGroups
+  #if(!$util.isNull($m.viewerGroups) && $util.list.copyAndRetain($m.viewerGroups, $userGroups).size() > 0)
+    #set($hasAccess = true)
+  #end
+
+  #if(!$hasAccess)
+    $util.unauthorized()
+  #end
+
+  $util.toJson($m)
+#end

--- a/amplify/backend/api/kiyanaw/resolvers/Query.listMedia.req.vtl
+++ b/amplify/backend/api/kiyanaw/resolvers/Query.listMedia.req.vtl
@@ -1,0 +1,7 @@
+## Request mapping template for Query.listMedia
+{
+  "version": "2018-05-29",
+  "operation": "Scan",
+  "limit": $util.defaultIfNull($ctx.arguments.limit, 100),
+  "nextToken": $util.toJson($ctx.arguments.nextToken)
+}

--- a/amplify/backend/api/kiyanaw/resolvers/Query.listMedia.res.vtl
+++ b/amplify/backend/api/kiyanaw/resolvers/Query.listMedia.res.vtl
@@ -1,0 +1,51 @@
+## Response mapping template for Query.listMedia
+## Filters results to records where the requesting user has explicit access
+
+#set($out = [])
+#set($userSub = $ctx.identity.claims.get("sub"))
+#set($userGroups = $ctx.identity.claims.get("cognito:groups"))
+
+#if($util.isNull($userSub))
+  #set($userSub = "")
+#end
+#if($util.isNull($userGroups))
+  #set($userGroups = [])
+#end
+
+#foreach($item in $ctx.result.items)
+  #set($hasAccess = false)
+
+  ## Owner
+  #if(!$util.isNull($item.owner) && $item.owner == $userSub)
+    #set($hasAccess = true)
+  #end
+
+  ## editors array
+  #if(!$util.isNull($item.editors) && $item.editors.contains($userSub))
+    #set($hasAccess = true)
+  #end
+
+  ## viewers array
+  #if(!$util.isNull($item.viewers) && $item.viewers.contains($userSub))
+    #set($hasAccess = true)
+  #end
+
+  ## editorGroups
+  #if(!$util.isNull($item.editorGroups) && $util.list.copyAndRetain($item.editorGroups, $userGroups).size() > 0)
+    #set($hasAccess = true)
+  #end
+
+  ## viewerGroups
+  #if(!$util.isNull($item.viewerGroups) && $util.list.copyAndRetain($item.viewerGroups, $userGroups).size() > 0)
+    #set($hasAccess = true)
+  #end
+
+  #if($hasAccess)
+    $util.qr($out.add($item))
+  #end
+#end
+
+$util.toJson({
+  "items": $out,
+  "nextToken": $ctx.result.nextToken
+})

--- a/amplify/backend/api/kiyanaw/resolvers/README.md
+++ b/amplify/backend/api/kiyanaw/resolvers/README.md
@@ -1,19 +1,32 @@
 # Custom VTL Resolvers for Fine-Grained Authorization
 
-This directory contains custom VTL (Velocity Template Language) resolvers that implement fine-grained authorization based on the `isPrivate` field in Transcription models.
+This directory contains custom VTL (Velocity Template Language) resolvers that implement fine-grained authorization for Transcription and Media models.
 
 ## Authorization Logic
 
-### For `isPrivate = false` (Public)
+### Transcription
+
+#### For `isPrivate = false` (Public)
 - Any authenticated user can read the Transcription and its Regions
 - Basic authentication check only
 
-### For `isPrivate = true` (Private)  
+#### For `isPrivate = true` (Private)
 - Only users in the following ACL lists can access:
   - `editors` array (per-document user IDs)
-  - `viewers` array (per-document user IDs) 
+  - `viewers` array (per-document user IDs)
   - `editorGroups` array (Cognito group names)
   - `viewerGroups` array (Cognito group names)
+
+### Media
+
+Media is always ACL-enforced — there is no public mode. Access is granted to:
+  - `owner` (the uploading user)
+  - `editors` array (per-record user IDs)
+  - `viewers` array (per-record user IDs)
+  - `editorGroups` array (Cognito group names)
+  - `viewerGroups` array (Cognito group names)
+
+The editors/viewers lists on a Media record should be kept in sync with the Transcription that references it whenever sharing permissions change.
 
 ## Implemented Resolvers
 
@@ -21,6 +34,8 @@ This directory contains custom VTL (Velocity Template Language) resolvers that i
 - `Query.getTranscription.req.vtl` / `Query.getTranscription.res.vtl` - Single transcription with ACL enforcement
 - `Query.listTranscriptions.req.vtl` / `Query.listTranscriptions.res.vtl` - List with filtering based on ACLs
 - `Query.getRegion.req.vtl` / `Query.getRegion.res.vtl` - Single region (simplified, needs parent lookup)
+- `Query.getMedia.req.vtl` / `Query.getMedia.res.vtl` - Single media record with ACL enforcement
+- `Query.listMedia.req.vtl` / `Query.listMedia.res.vtl` - List filtered to records the requesting user can access
 
 ### Subscription Resolvers (Response Only)
 - `Subscription.onCreateRegion.res.vtl` - Create notifications with auth check

--- a/amplify/backend/api/kiyanaw/schema.graphql
+++ b/amplify/backend/api/kiyanaw/schema.graphql
@@ -25,7 +25,9 @@ type Transcription
   regionCount: Int
   issueCount: Int
   tags: String
-  source: String
+  source: String # deprecated, use mediaId
+  mediaId: ID @index(name: "ByMedia", queryField: "transcriptionsByMedia")
+  media: Media @belongsTo(fields: ["mediaId"])
   index: String # deprecated field, use `lang`
   lang: String
   title: String! @index(name: "ByTitle", queryField: "byTitle")
@@ -47,8 +49,8 @@ type Transcription
 type Region
   @model
   @auth(rules: [
-    # Any authenticated User Pool user can read regions.                                                                                                                
-    # Mutations are allowed for authenticated users — the UI restricts access to editor/owner                                                                           
+    # Any authenticated User Pool user can read regions.
+    # Mutations are allowed for authenticated users — the UI restricts access to editor/owner
     # roles, and parent-ACL enforcement via custom VTL resolvers restricts mutations to the parent transcription's author/editors.
     { allow: private, operations: [create, read, update, delete] }
   ]) {
@@ -71,10 +73,10 @@ type Issue
   @auth(rules: [
     # 1) Owners (issue creators) can manage their own issues
     { allow: owner, ownerField: "owner", operations: [create, read, update, delete] }
-    
+
     # 3) Inherit access from parent transcription - users with transcription access can read/update issues
     { allow: private, operations: [read, update] }
-    
+
     # 4) Admins can manage all issues
     { allow: groups, groups: ["Admins"], operations: [create, read, update, delete] }
   ]) {
@@ -99,10 +101,10 @@ type Invite
   @auth(rules: [
     # 1) Owners (who sent the invite) can manage their invites
     { allow: owner, ownerField: "invitedBy", operations: [create, read, update, delete] }
-    
+
     # 3) Allow invited user to read their own invites by email
     { allow: owner, ownerField: "email", operations: [read, update] }
-    
+
     # 4) Admins can manage all invites
     { allow: groups, groups: ["Admins"], operations: [create, read, update, delete] }
   ]) {
@@ -124,33 +126,33 @@ type Comment
   @auth(rules: [
     # 1) Owners (comment authors) can manage their comments
     { allow: owner, ownerField: "author", operations: [create, read, update, delete] }
-    
+
     # 3) Inherit access from parent transcription - users with access can read comments
     { allow: private, operations: [read] }
-    
+
     # 4) Admins can manage all comments
     { allow: groups, groups: ["Admins"], operations: [create, read, update, delete] }
   ]) {
   id: ID! @primaryKey
-  
+
   # Content fields
   text: String!
   # User-based indexing for "my comments" across transcriptions
   author: String! @index(name: "ByAuthor", queryField: "commentsByAuthor", sortKeyFields: ["createdAt"])
   authorFriendly: String! # Friendly identifier (email/username)
-  
+
   # Timestamp fields
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
-  
+
   # Parent references - transcriptionId is ALWAYS present for efficient querying
   transcriptionId: ID! @index(name: "ByTranscription", queryField: "commentsByTranscription")
   transcription: Transcription! @belongsTo(fields: ["transcriptionId"])
-  
+
   # Entity reference within the transcription
   entityType: String! # "region", "issue", "transcription" (for transcription-level comments)
   entityId: String! # ID of the specific entity (regionId, issueId, or transcriptionId)
-  
+
   # Threading support for nested replies
   parentCommentId: ID @index(name: "ByParentComment", queryField: "commentsByParentComment")
   parentComment: Comment @belongsTo(fields: ["parentCommentId"])
@@ -158,4 +160,40 @@ type Comment
 
   # Optional extensible metadata
   metadata: AWSJSON
+}
+
+type Media
+  @model
+  @auth(rules: [
+    { allow: owner, ownerField: "owner", operations: [create, read, update, delete] }
+    { allow: owner, ownerField: "editors", operations: [read, update] }
+    { allow: owner, ownerField: "viewers", operations: [read] }
+    { allow: groups, groups: ["Admins"], operations: [create, read, update, delete] }
+  ]) {
+  id: ID! @primaryKey
+  pk: String! @index(name: "ByPkSk", queryField: "mediaByPkSk", sortKeyFields: ["sk"]) # e.g. "USER#<userId>"
+  sk: String! # e.g. "MEDIA#2024-03-15#<id>", or "MEDIA#0000-00-00#<id>" if recordedAt is unknown
+  owner: String! @index(name: "ByOwner", queryField: "mediaByOwner")
+
+  # Processing
+  status: String!
+  originalKey: String!
+  renditionKey: String
+  thumbnailKey: String
+
+  # Metadata
+  mimeType: String!
+  fileSize: Int!
+  duration: Float
+  tags: [String]
+  recordedAt: String
+
+  # ACL fields
+  editors: [String]
+  viewers: [String]
+  editorGroups: [String]
+  viewerGroups: [String]
+
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
 }


### PR DESCRIPTION
Adds a Media model to the GraphQL schema and custom VTL resolvers for getMedia/listMedia that enforce ACL on every request. Unlike Transcription, Media has no public mode — access always requires the requesting user to be the owner, in the editors/viewers lists, or in an editorGroups/viewerGroups Cognito group.

Also links Transcription to Media via a mediaId field (the existing source field is marked deprecated), and documents the Media ACL contract in the resolvers README.

Note: the editors/viewers lists on a Media record should be kept in sync with the parent Transcription whenever sharing permissions change — this sync logic is not yet implemented.

### Testing

No automated tests cover VTL resolvers. Manually verified by inspecting the resolver logic against the ACL rules defined in the schema. Full integration testing will come when the upload flow is wired up.