### PR TITLE
Fix Slack error notification showing [object Object]

### DIFF
--- a/amplify/hooks/lib/slack.js
+++ b/amplify/hooks/lib/slack.js
@@ -45,6 +45,14 @@ function formatDuration(ms) {
   return mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
 }
 
+export function serializeError(err) {
+  if (typeof err === 'string') return err;
+  if (err && typeof err === 'object') {
+    return typeof err.message === 'string' ? err.message : JSON.stringify(err);
+  }
+  return String(err);
+}
+
 export function buildStartMessage({ envName, lifecycle, gitUser, branch, sha }) {
   return [
     `:rocket: *Deployment started* for \`${envName}\``,

--- a/amplify/hooks/lib/slack.test.js
+++ b/amplify/hooks/lib/slack.test.js
@@ -1,0 +1,44 @@
+import { buildFinishMessage, serializeError } from './slack.js';
+
+describe('serializeError', () => {
+  it('returns string as-is', () => {
+    expect(serializeError('some error')).toBe('some error');
+  });
+
+  it('extracts message from object with message field', () => {
+    expect(serializeError({ message: 'something went wrong', code: 42 })).toBe('something went wrong');
+  });
+
+  it('JSON-stringifies objects without a message field', () => {
+    expect(serializeError({ code: 'ERR_FAIL', details: 'bad' })).toBe('{"code":"ERR_FAIL","details":"bad"}');
+  });
+
+  it('handles null', () => {
+    expect(serializeError(null)).toBe('null');
+  });
+});
+
+describe('buildFinishMessage with object error', () => {
+  const base = {
+    envName: 'staging',
+    lifecycle: 'publish',
+    gitUser: 'Dan Fay',
+    branch: 'staging',
+    sha: 'abc1234',
+    success: false,
+    stage: 'amplify publish',
+    durationMs: 81000,
+  };
+
+  it('does not show [object Object] when error is an object with a message', () => {
+    const msg = buildFinishMessage({ ...base, error: serializeError({ message: 'Deploy failed: stack rollback' }) });
+    expect(msg).toContain('Deploy failed: stack rollback');
+    expect(msg).not.toContain('[object Object]');
+  });
+
+  it('does not show [object Object] when error is a plain object', () => {
+    const msg = buildFinishMessage({ ...base, error: serializeError({ code: 'ERR_DEPLOY', reason: 'timeout' }) });
+    expect(msg).not.toContain('[object Object]');
+    expect(msg).toContain('ERR_DEPLOY');
+  });
+});

--- a/amplify/hooks/post-publish.js
+++ b/amplify/hooks/post-publish.js
@@ -17,7 +17,7 @@ import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { getAmplifyEnv, getGitContext, projectRoot, readStartFile, deleteStartFile } from './lib/deploy-context.js';
-import { getWebhookUrl, postToSlack, buildFinishMessage } from './lib/slack.js';
+import { getWebhookUrl, postToSlack, buildFinishMessage, serializeError } from './lib/slack.js';
 
 let input = '';
 process.stdin.on('data', (chunk) => {
@@ -48,7 +48,7 @@ process.stdin.on('end', async () => {
 
     if (hookData.error) {
       console.log('Amplify publish encountered an error. Skipping Serverless deployment.');
-      await notifyFinish({ success: false, stage: 'amplify publish', error: String(hookData.error) });
+      await notifyFinish({ success: false, stage: 'amplify publish', error: serializeError(hookData.error) });
       process.exit(0);
     }
 

--- a/amplify/hooks/post-push.js
+++ b/amplify/hooks/post-push.js
@@ -14,7 +14,7 @@ import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { getAmplifyEnv, getGitContext, projectRoot, readStartFile, deleteStartFile } from './lib/deploy-context.js';
-import { getWebhookUrl, postToSlack, buildFinishMessage } from './lib/slack.js';
+import { getWebhookUrl, postToSlack, buildFinishMessage, serializeError } from './lib/slack.js';
 
 let input = '';
 process.stdin.on('data', (chunk) => {
@@ -50,7 +50,7 @@ process.stdin.on('end', async () => {
 
     if (hookData.error) {
       console.log('Amplify push encountered an error. Skipping Serverless deployment.');
-      await notifyFinish({ success: false, stage: 'amplify push', error: String(hookData.error) });
+      await notifyFinish({ success: false, stage: 'amplify push', error: serializeError(hookData.error) });
       process.exit(0);
     }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -112,5 +112,26 @@ export default {
         '/node_modules/',
       ],
     },
+    // Amplify hooks tests
+    {
+      displayName: 'Amplify Hooks',
+      testEnvironment: 'node',
+      testMatch: [
+        '<rootDir>/amplify/hooks/**/*.test.js',
+      ],
+      transform: {
+        '^.+\\.js$': ['ts-jest', {
+          tsconfig: {
+            esModuleInterop: true,
+            allowSyntheticDefaultImports: true,
+            allowJs: true,
+            target: 'ES2020',
+          },
+        }],
+      },
+      testPathIgnorePatterns: [
+        '/node_modules/',
+      ],
+    },
   ],
 }; 


### PR DESCRIPTION
resolve #257

Amplify passes hook errors as JSON objects; calling String() on them produced "[object Object]" in Slack failure messages. Added a serializeError() helper that extracts err.message or falls back to JSON.stringify, and updated both post-publish and post-push hooks to use it.

### Testing

6 new unit tests in amplify/hooks/lib/slack.test.js. Full suite passes.