### PR TITLE
Fix "shared with me" tab showing stale transcriptions after logout or account switch

### DIFF
--- a/src/components/auth/AuthenticatorShell.tsx
+++ b/src/components/auth/AuthenticatorShell.tsx
@@ -1,6 +1,9 @@
 import { Authenticator, useAuthenticator, ThemeProvider, createTheme } from '@aws-amplify/ui-react';
 import { useRef, type ReactNode } from 'react';
 import { useAuthStore } from '../../stores/useAuthStore';
+import { useTranscriptionsStore } from '../../stores/useTranscriptionsStore';
+import { useInviteStore } from '../../stores/useInviteStore';
+import { clearTranscriptionCache } from '../../services/transcriptionService';
 
 interface AuthenticatorShellProps {
   children: ReactNode;
@@ -18,18 +21,33 @@ const AuthenticatedApp = ({ children }: { children: ReactNode }) => {
   const currentUserKey = route === 'authenticated' && user ? user.userId : 'null';
   
   if (lastUserRef.current !== currentUserKey) {
+    const previousUserKey = lastUserRef.current;
     lastUserRef.current = currentUserKey;
-    
+
     const currentUser = route === 'authenticated' && user ? {
       username: user.signInDetails?.loginId as string,  // This is the email
       userId: user.userId,
       signInDetails: user.signInDetails,
     } : null;
-    
+
     // Check if the store actually needs updating
     const storeUser = useAuthStore.getState().user;
     const storeUserKey = storeUser ? storeUser.userId : 'null';
-    
+
+    // When switching between two authenticated users in the same session,
+    // clear the previous user's cache before loading the new user's data.
+    const switchingUsers =
+      previousUserKey !== '__initial__' &&
+      previousUserKey !== 'null' &&
+      currentUserKey !== 'null' &&
+      previousUserKey !== currentUserKey;
+
+    if (switchingUsers) {
+      clearTranscriptionCache().catch(console.error);
+      useTranscriptionsStore.getState().reset();
+      useInviteStore.getState().reset();
+    }
+
     if (storeUserKey !== currentUserKey) {
       useAuthStore.getState().setUser(currentUser);
     }

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -2,9 +2,12 @@ import { useState, useRef, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Download, LogOut, HelpCircle, BookOpen, Database } from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
+import { useTranscriptionsStore } from '../../stores/useTranscriptionsStore';
+import { useInviteStore } from '../../stores/useInviteStore';
 import { useLoadMyInvites } from '../../hooks/useLoadMyInvites';
 import { GuardedLink } from './GuardedLink';
 import { signOut } from 'aws-amplify/auth';
+import { clearTranscriptionCache } from '../../services/transcriptionService';
 import { canPromptInstall, promptInstall, shouldShowInstall, isIosDevice } from '../../services/pwaInstallService';
 
 export const AppLayout = () => {
@@ -25,6 +28,9 @@ export const AppLayout = () => {
 
   const handleSignOut = async () => {
     try {
+      await clearTranscriptionCache();
+      useTranscriptionsStore.getState().reset();
+      useInviteStore.getState().reset();
       await signOut();
       setProfileDropdownOpen(false);
     } catch (error) {

--- a/src/services/transcriptionService.test.ts
+++ b/src/services/transcriptionService.test.ts
@@ -1,4 +1,4 @@
-import { loadInFull, loadAll, __resetClient } from './transcriptionService';
+import { loadInFull, loadAll, __resetClient, clearTranscriptionCache, isSyncing } from './transcriptionService';
 import { generateClient } from 'aws-amplify/api';
 import { loadRegionsForTranscription } from './regionService';
 import { loadIssuesForTranscription } from './issueService';
@@ -800,10 +800,23 @@ describe('TranscriptionService', () => {
         (transcriptionStorage.getAll as jest.Mock).mockResolvedValueOnce(minimalCachedTranscriptions);
 
         const result = await loadAll();
-        
+
         expect(Array.isArray(result)).toBe(true);
         expect(result.length).toBeGreaterThanOrEqual(0);
       });
+    });
+  });
+
+  describe('clearTranscriptionCache', () => {
+    it('delegates to transcriptionStorage.clearCache', async () => {
+      await clearTranscriptionCache();
+      expect(transcriptionStorage.clearCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets currentSyncOperation so no stale sync can repopulate the cache', async () => {
+      expect(isSyncing()).toBe(false);
+      await clearTranscriptionCache();
+      expect(isSyncing()).toBe(false);
     });
   });
 }); 

--- a/src/services/transcriptionService.ts
+++ b/src/services/transcriptionService.ts
@@ -665,6 +665,15 @@ const loadOwnedTranscriptionsSince = async (userId: string, sinceDate: string): 
 };
 
 /**
+ * Clear all cached transcription data and reset in-flight sync state.
+ * Call this on logout or account switch before loading data for the new user.
+ */
+export const clearTranscriptionCache = async (): Promise<void> => {
+  currentSyncOperation = null;
+  await transcriptionStorage.clearCache();
+};
+
+/**
  * Check if a sync operation is currently in progress
  */
 export const isSyncing = (): boolean => currentSyncOperation !== null;

--- a/src/stores/useInviteStore.test.ts
+++ b/src/stores/useInviteStore.test.ts
@@ -1,0 +1,41 @@
+import { useInviteStore } from './useInviteStore';
+
+jest.mock('../services');
+
+describe('useInviteStore', () => {
+  beforeEach(() => {
+    useInviteStore.setState({
+      invites: [],
+      invitesLoading: false,
+      invitesError: null,
+      pendingCount: 0,
+      loadedForUser: null,
+      currentInvite: null,
+      currentInviteLoading: false,
+      currentInviteError: null,
+      currentInviteValidation: null,
+      loadedInviteId: null,
+    });
+  });
+
+  describe('reset()', () => {
+    it('clears invites list and resets pending count', () => {
+      useInviteStore.setState({
+        invites: [{ invite: { id: 'inv-1' }, validation: { canAccept: true } }] as any,
+        pendingCount: 1,
+        invitesLoading: false,
+        invitesError: null,
+        loadedForUser: 'user-a@example.com',
+      });
+
+      useInviteStore.getState().reset();
+
+      const state = useInviteStore.getState();
+      expect(state.invites).toEqual([]);
+      expect(state.pendingCount).toBe(0);
+      expect(state.invitesLoading).toBe(false);
+      expect(state.invitesError).toBeNull();
+      expect(state.loadedForUser).toBeNull();
+    });
+  });
+});

--- a/src/stores/useInviteStore.ts
+++ b/src/stores/useInviteStore.ts
@@ -31,6 +31,7 @@ interface InviteState {
   clearCurrentInvite: () => void;
   markInviteAsAccepted: (inviteId: string) => void;
   refresh: () => Promise<void>;
+  reset: () => void;
 }
 
 export const useInviteStore = create<InviteState>()(
@@ -254,6 +255,17 @@ export const useInviteStore = create<InviteState>()(
         console.log('✅ Invite marked as accepted, pending count updated:', { 
           inviteId, 
           newPendingCount 
+        });
+      },
+
+      // Reset all state (used on logout / account switch)
+      reset: () => {
+        set({
+          invites: [],
+          invitesLoading: false,
+          invitesError: null,
+          pendingCount: 0,
+          loadedForUser: null,
         });
       },
 

--- a/src/stores/useTranscriptionsStore.test.ts
+++ b/src/stores/useTranscriptionsStore.test.ts
@@ -1,0 +1,61 @@
+import { useTranscriptionsStore } from './useTranscriptionsStore';
+import { TranscriptionModel } from '../services/adt';
+
+jest.mock('../services/adt');
+jest.mock('../services');
+jest.mock('../use-cases/load-transcriptions');
+
+describe('useTranscriptionsStore', () => {
+  beforeEach(() => {
+    useTranscriptionsStore.setState({
+      transcriptions: [],
+      loading: false,
+      error: null,
+      isSyncing: false,
+      lastSyncedAt: null,
+      cacheStats: null,
+      ownedSyncStatus: null,
+      sharedSyncStatus: null,
+    });
+  });
+
+  describe('reset()', () => {
+    it('clears transcriptions and resets all state to initial values', () => {
+      const mockModel = { id: 'tx-1', author: 'user-a' } as TranscriptionModel;
+      useTranscriptionsStore.setState({
+        transcriptions: [mockModel],
+        loading: true,
+        error: 'some error',
+        isSyncing: true,
+        lastSyncedAt: '2025-01-01T00:00:00Z',
+        cacheStats: { count: 1, lastSyncedAt: '2025-01-01T00:00:00Z' },
+        ownedSyncStatus: 'synced',
+        sharedSyncStatus: 'syncing',
+      });
+
+      useTranscriptionsStore.getState().reset();
+
+      const state = useTranscriptionsStore.getState();
+      expect(state.transcriptions).toEqual([]);
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+      expect(state.isSyncing).toBe(false);
+      expect(state.lastSyncedAt).toBeNull();
+      expect(state.cacheStats).toBeNull();
+      expect(state.ownedSyncStatus).toBeNull();
+      expect(state.sharedSyncStatus).toBeNull();
+    });
+
+    it('results in an empty shared-with-me list after account switch', () => {
+      const mockModel = { id: 'tx-1', author: 'user-a', isMine: () => false } as unknown as TranscriptionModel;
+      useTranscriptionsStore.getState().setTranscriptions([mockModel]);
+
+      // Simulate: new user B logs in and the store is reset before their data loads
+      useTranscriptionsStore.getState().reset();
+
+      const { transcriptions } = useTranscriptionsStore.getState();
+      const sharedWithMe = transcriptions.filter((t) => !t.isMine('user-b-id'));
+      expect(sharedWithMe).toHaveLength(0);
+    });
+  });
+});

--- a/src/stores/useTranscriptionsStore.ts
+++ b/src/stores/useTranscriptionsStore.ts
@@ -37,7 +37,10 @@ interface TranscriptionsState {
   // Tab-specific sync actions
   setOwnedSyncStatus: (status: 'synced' | 'syncing' | null) => void;
   setSharedSyncStatus: (status: 'synced' | 'syncing' | null) => void;
-  
+
+  // Reset all state (used on logout / account switch)
+  reset: () => void;
+
   // Legacy action
   reload: () => void;
 }
@@ -107,7 +110,21 @@ export const useTranscriptionsStore = create<TranscriptionsState>()(
       setSharedSyncStatus: (sharedSyncStatus: 'synced' | 'syncing' | null) => {
         set({ sharedSyncStatus });
       },
-      
+
+      // Reset all state (used on logout / account switch)
+      reset: () => {
+        set({
+          transcriptions: [],
+          loading: false,
+          error: null,
+          isSyncing: false,
+          lastSyncedAt: null,
+          cacheStats: null,
+          ownedSyncStatus: null,
+          sharedSyncStatus: null,
+        });
+      },
+
       // Legacy action
       reload: () => {
         const store = useTranscriptionsStore.getState();


### PR DESCRIPTION
resolve #265

Clears the transcription service cache and resets `useTranscriptionsStore` and `useInviteStore` before signing out in `AppLayout`, so the next login always starts with a clean slate. Also handles the back-to-back account switch case in `AuthenticatorShell`, where one user logs out and another immediately logs in within the same session without a page reload.

### Testing
New unit tests in `useTranscriptionsStore.test.ts` and `useInviteStore.test.ts` verify that `reset()` clears all state fields. The second store test explicitly covers the account-switch scenario, asserting that the previous user's transcriptions are not visible to the incoming user. Manually tested locally by switching between two accounts and confirming the "shared with me" tab shows only the current user's data.