### PR TITLE
Fix overlapping region auto-selection during bounded playback

### DIFF
--- a/src/hooks/useWavesurferEvents.test.ts
+++ b/src/hooks/useWavesurferEvents.test.ts
@@ -101,6 +101,7 @@ describe('useWavesurferEvents', () => {
     // Mock wavesurferService methods
     (wavesurferService.clearAllListeners as jest.Mock).mockImplementation(mockClearAllListeners);
     (wavesurferService.on as jest.Mock).mockImplementation(mockOn);
+    (wavesurferService.getPlaybackBoundRegion as jest.Mock).mockReturnValue(null);
   });
 
   describe('useEffect behavior', () => {
@@ -638,6 +639,48 @@ describe('useWavesurferEvents', () => {
       // Exit region2 - should work since it's the currently tracked region
       regionOutHandler({ regionId: region2 });
       expect(mockRemoveCustomStyle).toHaveBeenCalledWith('style-id-2');
+    });
+
+    it('should not select an overlapping region when playback is bound to a different region', () => {
+      const transcriptionId = 'test-transcription-1';
+      const boundRegionId = 'region-playing';
+      const overlappingRegionId = 'region-overlapping';
+
+      (wavesurferService.getPlaybackBoundRegion as jest.Mock).mockReturnValue({
+        id: boundRegionId,
+        start: 0,
+        end: 10,
+      });
+
+      renderHook(() => useWavesurferEvents(transcriptionId));
+
+      const regionInHandler = mockOn.mock.calls.find(call => call[0] === 'region-in')[1];
+
+      // Simulate region-in for the overlapping region (not the bound one)
+      regionInHandler({ regionId: overlappingRegionId });
+
+      expect(mockStore.setSelectedRegion).not.toHaveBeenCalled();
+      expect(mockAddCustomStyle).not.toHaveBeenCalled();
+      expect(mockScrollElementIntoView).not.toHaveBeenCalled();
+    });
+
+    it('should select the bound region when region-in fires for it during bounded playback', () => {
+      const transcriptionId = 'test-transcription-1';
+      const boundRegionId = 'region-playing';
+
+      (wavesurferService.getPlaybackBoundRegion as jest.Mock).mockReturnValue({
+        id: boundRegionId,
+        start: 0,
+        end: 10,
+      });
+
+      renderHook(() => useWavesurferEvents(transcriptionId));
+
+      const regionInHandler = mockOn.mock.calls.find(call => call[0] === 'region-in')[1];
+
+      regionInHandler({ regionId: boundRegionId });
+
+      expect(mockStore.setSelectedRegion).toHaveBeenCalledWith(boundRegionId);
     });
   });
 

--- a/src/hooks/useWavesurferEvents.ts
+++ b/src/hooks/useWavesurferEvents.ts
@@ -111,6 +111,13 @@ export const useWavesurferEvents = (transcriptionId: string, source?: string): v
     const handleRegionIn = (data: unknown) => {
       const { regionId } = data as RegionEvent;
 
+      // During region-bounded playback, overlapping regions also fire `region-in`.
+      // Ignore those so selection, highlight, and scroll stay on the played region.
+      const boundRegion = wavesurferService.getPlaybackBoundRegion();
+      if (boundRegion && boundRegion.id !== regionId) {
+        return;
+      }
+
       useEditorStore.getState().setSelectedRegion(regionId);
 
       if (highlightedInboundRegionRef.current) {

--- a/src/services/wavesurferService.test.ts
+++ b/src/services/wavesurferService.test.ts
@@ -1079,6 +1079,35 @@ describe('WaveSurferService', () => {
       });
     });
 
+    it('should not tint an overlapping region during bounded playback', () => {
+      wavesurferService.initialize(mockContainer, mockTimelineContainer);
+
+      const regionInCallback = mockRegionsInstance.on.mock.calls.find(
+        (call: any) => call[0] === 'region-in'
+      )[1];
+
+      const boundElement = { style: { backgroundColor: '' } };
+      const overlappingElement = { style: { backgroundColor: '' } };
+
+      // Arm bounded playback on the first region
+      wavesurferService.seekToRegion({ id: 'region-bound', start: 0, end: 10 });
+
+      // Enter the bound region (should highlight)
+      regionInCallback({ id: 'region-bound', element: boundElement });
+      expect(boundElement.style.backgroundColor).toBe('rgba(0, 213, 255, 0.1)');
+
+      // Enter the overlapping region while still bounded to the first
+      regionInCallback({ id: 'region-overlapping', element: overlappingElement });
+
+      // Overlapping region must NOT be highlighted, bound region must stay highlighted
+      expect(overlappingElement.style.backgroundColor).toBe('');
+      expect(boundElement.style.backgroundColor).toBe('rgba(0, 213, 255, 0.1)');
+      expect(wavesurferService['_inboundRegionCurrentHighlighted']).toEqual({
+        id: 'region-bound',
+        element: boundElement,
+      });
+    });
+
     it('should clear highlighted region tracking on normal region-out', () => {
       wavesurferService.initialize(mockContainer, mockTimelineContainer);
       

--- a/src/services/wavesurferService.test.ts
+++ b/src/services/wavesurferService.test.ts
@@ -904,14 +904,26 @@ describe('WaveSurferService', () => {
 
     it('should clear region-bounded playback when calling clearRegionBoundedPlayback', () => {
       const testRegion = { id: 'test-region', start: 25.5, end: 35.2 };
-      
+
       // First arm the guard
       wavesurferService.seekToRegion(testRegion);
       expect(wavesurferService['_playbackBoundRegion']).toEqual(testRegion);
-      
+
       // Then clear it
       wavesurferService.clearRegionBoundedPlayback();
       expect(wavesurferService['_playbackBoundRegion']).toBeNull();
+    });
+
+    it('should return the bound region via getPlaybackBoundRegion after seekToRegion', () => {
+      const testRegion = { id: 'test-region', start: 5.0, end: 10.0 };
+
+      expect(wavesurferService.getPlaybackBoundRegion()).toBeNull();
+
+      wavesurferService.seekToRegion(testRegion);
+      expect(wavesurferService.getPlaybackBoundRegion()).toEqual(testRegion);
+
+      wavesurferService.clearRegionBoundedPlayback();
+      expect(wavesurferService.getPlaybackBoundRegion()).toBeNull();
     });
 
     it('should stop playback when reaching end of bounded region', () => {

--- a/src/services/wavesurferService.ts
+++ b/src/services/wavesurferService.ts
@@ -284,7 +284,13 @@ class WaveSurferService {
       if (!regionEvent?.element) {
         return;
       }
-      
+
+      // During bounded playback, overlapping regions fire region-in too. Ignore
+      // them so the waveform highlight and selection stay on the played region.
+      if (this._playbackBoundRegion && this._playbackBoundRegion.id !== regionEvent.id) {
+        return;
+      }
+
       const previouslyHighlightedInboundRegion = this._inboundRegionCurrentHighlighted !== null;
       const newRegionInIsDifferent = previouslyHighlightedInboundRegion && this._inboundRegionCurrentHighlighted?.id !== regionEvent.id;
       const needToClearHighlight = newRegionInIsDifferent;

--- a/src/services/wavesurferService.ts
+++ b/src/services/wavesurferService.ts
@@ -533,6 +533,10 @@ class WaveSurferService {
     }
   }
 
+  getPlaybackBoundRegion(): RegionEvent | null {
+    return this._playbackBoundRegion;
+  }
+
   /**
    * Clears the region-bounded playback guard, allowing free playback
    */


### PR DESCRIPTION
resolve #286

When two regions overlap in time, playing back the first region caused the wavesurfer `region-in` event to fire for the overlapping region too, jumping both the editor selection and the waveform highlight to the wrong region. Fixed by gating the service-level and hook-level `region-in` handlers to ignore events for any region other than the one playback is currently bounded to.

### Testing
Three new tests cover the fix: the service handler skips waveform tinting for overlapping regions during bounded playback, and the hook handler skips selection/highlight/scroll for non-bound regions while correctly proceeding for the bound region. The `getPlaybackBoundRegion()` getter is also tested directly. Full suite (2069 tests) passes. Also verified locally with two overlapping regions — selection, waveform highlight, and typing all stay on the played region throughout playback.