### PR TITLE
Show media processing status in list and editor

### DIFF
--- a/src/components/list/MediaStatusIndicator.test.tsx
+++ b/src/components/list/MediaStatusIndicator.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MediaStatusIndicator } from './MediaStatusIndicator';
+
+describe('MediaStatusIndicator', () => {
+  it('renders a spinner for PENDING status', () => {
+    render(<MediaStatusIndicator status="PENDING" />);
+    expect(screen.getByTestId('media-status-indicator')).toBeInTheDocument();
+    expect(screen.getByTitle('Processing media…')).toBeInTheDocument();
+  });
+
+  it('renders a spinner for PROCESSING status', () => {
+    render(<MediaStatusIndicator status="PROCESSING" />);
+    expect(screen.getByTestId('media-status-indicator')).toBeInTheDocument();
+    expect(screen.getByTitle('Processing media…')).toBeInTheDocument();
+  });
+
+  it('renders an error icon for ERROR status', () => {
+    render(<MediaStatusIndicator status="ERROR" />);
+    expect(screen.getByTestId('media-status-indicator')).toBeInTheDocument();
+    expect(screen.getByTitle('Media processing failed')).toBeInTheDocument();
+  });
+
+  it('renders nothing for READY status', () => {
+    const { container } = render(<MediaStatusIndicator status="READY" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when status is undefined', () => {
+    const { container } = render(<MediaStatusIndicator status={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/list/MediaStatusIndicator.tsx
+++ b/src/components/list/MediaStatusIndicator.tsx
@@ -1,0 +1,34 @@
+import { Loader2, TriangleAlert } from 'lucide-react';
+import { MEDIA_STATUS } from '../../services/mediaService';
+
+interface MediaStatusIndicatorProps {
+  status: string | undefined;
+}
+
+export const MediaStatusIndicator = ({ status }: MediaStatusIndicatorProps) => {
+  if (status === MEDIA_STATUS.PENDING || status === MEDIA_STATUS.PROCESSING) {
+    return (
+      <div
+        className="flex items-center justify-center w-4 h-4 flex-shrink-0"
+        title="Processing media…"
+        data-testid="media-status-indicator"
+      >
+        <Loader2 size={14} className="text-blue-500 animate-spin" />
+      </div>
+    );
+  }
+
+  if (status === MEDIA_STATUS.ERROR) {
+    return (
+      <div
+        className="flex items-center justify-center w-4 h-4 flex-shrink-0"
+        title="Media processing failed"
+        data-testid="media-status-indicator"
+      >
+        <TriangleAlert size={14} className="text-red-500" />
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/src/components/list/MediaStatusIndicator.tsx
+++ b/src/components/list/MediaStatusIndicator.tsx
@@ -1,4 +1,4 @@
-import { Loader2, TriangleAlert } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { MEDIA_STATUS } from '../../services/mediaService';
 
 interface MediaStatusIndicatorProps {
@@ -8,25 +8,26 @@ interface MediaStatusIndicatorProps {
 export const MediaStatusIndicator = ({ status }: MediaStatusIndicatorProps) => {
   if (status === MEDIA_STATUS.PENDING || status === MEDIA_STATUS.PROCESSING) {
     return (
-      <div
-        className="flex items-center justify-center w-4 h-4 flex-shrink-0"
+      <span
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700 flex-shrink-0"
         title="Processing media…"
         data-testid="media-status-indicator"
       >
-        <Loader2 size={14} className="text-blue-500 animate-spin" />
-      </div>
+        <Loader2 size={10} className="animate-spin" />
+        Processing
+      </span>
     );
   }
 
   if (status === MEDIA_STATUS.ERROR) {
     return (
-      <div
-        className="flex items-center justify-center w-4 h-4 flex-shrink-0"
+      <span
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700 flex-shrink-0"
         title="Media processing failed"
         data-testid="media-status-indicator"
       >
-        <TriangleAlert size={14} className="text-red-500" />
-      </div>
+        Failed
+      </span>
     );
   }
 

--- a/src/components/list/TranscriptionsList.tsx
+++ b/src/components/list/TranscriptionsList.tsx
@@ -5,9 +5,11 @@ import { useTranscriptionsStore } from '../../stores/useTranscriptionsStore';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { useLoadTranscriptions } from '../../hooks/useLoadTranscriptions';
 import { SyncIndicator } from '../sync/SyncIndicator';
+import { MediaStatusIndicator } from './MediaStatusIndicator';
 import { SyncOwnedTranscriptions } from '../../use-cases/sync-owned-transcriptions';
 import { SyncSharedTranscriptions } from '../../use-cases/sync-shared-transcriptions';
 import { services } from '../../services';
+import { subscribeToMediaChanges } from '../../services/mediaService';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 
@@ -37,6 +39,7 @@ export const TranscriptionsList = () => {
   const reload = useTranscriptionsStore((state) => state.reload);
   const ownedSyncStatus = useTranscriptionsStore((state) => state.ownedSyncStatus);
   const sharedSyncStatus = useTranscriptionsStore((state) => state.sharedSyncStatus);
+  const applyMediaStatus = useTranscriptionsStore((state) => state.applyMediaStatus);
   const user = useAuthStore((state) => state.user);
   const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState('dateLastUpdated');
@@ -89,10 +92,20 @@ export const TranscriptionsList = () => {
 
   // Load transcriptions when component mounts
   const loadTranscriptions = useLoadTranscriptions();
-  
+
   useEffect(() => {
     loadTranscriptions();
   }, [loadTranscriptions]);
+
+  // Subscribe to media status updates for the current user's files
+  useEffect(() => {
+    if (!user?.userId) return;
+    const unsubscribe = subscribeToMediaChanges(
+      { owner: user.userId },
+      (media) => applyMediaStatus(media.id, media.status)
+    );
+    return unsubscribe;
+  }, [user?.userId, applyMediaStatus]);
 
   // Handle tab switching with sync
   const handleTabSwitch = (tab: TabType) => {
@@ -436,6 +449,8 @@ export const TranscriptionsList = () => {
                           {transcription.title}
                         </Link>
 
+                        <MediaStatusIndicator status={transcription.mediaStatus} />
+
                         {/* Media Type Icon */}
                         {transcription.isVideo ? (
                           <Video className="w-4 h-4 text-gray-500 flex-shrink-0" />
@@ -558,6 +573,8 @@ export const TranscriptionsList = () => {
                       >
                         {transcription.title}
                       </Link>
+
+                      <MediaStatusIndicator status={transcription.mediaStatus} />
 
                       {/* Sharing Status Icons */}
                       {(() => {

--- a/src/components/list/TranscriptionsList.tsx
+++ b/src/components/list/TranscriptionsList.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Users, Eye, Edit, Search, Plus, ChevronDown, Lock, LockOpen, Video, FileAudio, Filter, X, AlertTriangle, List } from 'lucide-react';
+import { Users, Eye, Edit, Search, Plus, ChevronDown, Lock, LockOpen, Video, FileAudio, Filter, X, AlertTriangle, List, Trash2 } from 'lucide-react';
+import { DeleteTranscriptionUseCase } from '../../use-cases/delete-transcription';
 import { useTranscriptionsStore } from '../../stores/useTranscriptionsStore';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { useLoadTranscriptions } from '../../hooks/useLoadTranscriptions';
@@ -40,6 +41,7 @@ export const TranscriptionsList = () => {
   const ownedSyncStatus = useTranscriptionsStore((state) => state.ownedSyncStatus);
   const sharedSyncStatus = useTranscriptionsStore((state) => state.sharedSyncStatus);
   const applyMediaStatus = useTranscriptionsStore((state) => state.applyMediaStatus);
+  const removeTranscription = useTranscriptionsStore((state) => state.removeTranscription);
   const user = useAuthStore((state) => state.user);
   const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState('dateLastUpdated');
@@ -47,6 +49,25 @@ export const TranscriptionsList = () => {
   const [showMobileSearch, setShowMobileSearch] = useState(false);
   const [showMobileFilter, setShowMobileFilter] = useState(false);
   const [activeTab, setActiveTab] = useState<TabType>('owned');
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const handleDelete = async (transcription: (typeof transcriptions)[0]) => {
+    setDeletingId(transcription.id);
+    try {
+      const useCase = new DeleteTranscriptionUseCase({
+        transcriptionId: transcription.id,
+        transcription: { source: transcription.source, mediaId: transcription.mediaId },
+      });
+      await useCase.execute();
+      removeTranscription(transcription.id);
+    } catch (error) {
+      console.error('Failed to delete transcription:', error);
+    } finally {
+      setDeletingId(null);
+      setConfirmDeleteId(null);
+    }
+  };
 
   const showUploadButton = true;
 
@@ -563,6 +584,36 @@ export const TranscriptionsList = () => {
                         <span className="text-gray-500">Updated</span>
                         <span className="text-gray-700">{formatTimeAgo(transcription.dateLastUpdated)}</span>
                       </div>
+                      {transcription.isMine(user?.userId) && (
+                        <div className="flex items-center justify-between text-sm pt-1 border-t border-gray-100">
+                          {confirmDeleteId === transcription.id ? (
+                            <div className="flex items-center gap-2 w-full">
+                              <span className="text-gray-600 text-xs">Delete this transcription?</span>
+                              <button
+                                onClick={() => handleDelete(transcription)}
+                                disabled={deletingId === transcription.id}
+                                className="ml-auto px-2 py-1 text-xs font-medium bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+                              >
+                                {deletingId === transcription.id ? 'Deleting…' : 'Confirm'}
+                              </button>
+                              <button
+                                onClick={() => setConfirmDeleteId(null)}
+                                className="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() => setConfirmDeleteId(transcription.id)}
+                              className="flex items-center gap-1 text-gray-400 hover:text-red-500 transition-colors"
+                            >
+                              <Trash2 className="w-3 h-3" />
+                              <span className="text-xs">Delete</span>
+                            </button>
+                          )}
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -626,7 +677,7 @@ export const TranscriptionsList = () => {
                         {(() => {
                           const issues = transcription.data.issueCount ?? Number(transcription.data.issues || 0);
                           const regions = transcription.data.regionCount ?? 0;
-                          
+
                           return (
                             <>
                         <span
@@ -636,7 +687,7 @@ export const TranscriptionsList = () => {
                         >
                                 {issues} issues
                               </span>
-                              <span 
+                              <span
                                 className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium text-cyan-800"
                                 style={{ backgroundColor: 'rgba(0, 213, 255, 0.15)' }}
                               >
@@ -645,6 +696,33 @@ export const TranscriptionsList = () => {
                             </>
                           );
                         })()}
+                        {transcription.isMine(user?.userId) && (
+                          confirmDeleteId === transcription.id ? (
+                            <div className="flex items-center gap-1">
+                              <button
+                                onClick={() => handleDelete(transcription)}
+                                disabled={deletingId === transcription.id}
+                                className="px-2 py-1 text-xs font-medium bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+                              >
+                                {deletingId === transcription.id ? 'Deleting…' : 'Confirm'}
+                              </button>
+                              <button
+                                onClick={() => setConfirmDeleteId(null)}
+                                className="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-700 rounded hover:bg-gray-200"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() => setConfirmDeleteId(transcription.id)}
+                              className="p-1 text-gray-400 hover:text-red-500 rounded transition-colors"
+                              title="Delete transcription"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </button>
+                          )
+                        )}
                       </div>
                     </div>
 

--- a/src/components/list/TranscriptionsList.tsx
+++ b/src/components/list/TranscriptionsList.tsx
@@ -9,7 +9,7 @@ import { MediaStatusIndicator } from './MediaStatusIndicator';
 import { SyncOwnedTranscriptions } from '../../use-cases/sync-owned-transcriptions';
 import { SyncSharedTranscriptions } from '../../use-cases/sync-shared-transcriptions';
 import { services } from '../../services';
-import { subscribeToMediaChanges } from '../../services/mediaService';
+import { MEDIA_STATUS } from '../../services/mediaService';
 import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 
@@ -97,16 +97,30 @@ export const TranscriptionsList = () => {
     loadTranscriptions();
   }, [loadTranscriptions]);
 
-  // Subscribe to media status updates for the current user's files.
-  // No explicit filter needed — Amplify owner auth restricts the subscription automatically.
+  // Poll media status for any transcriptions still processing.
+  // Lambda writes directly to DynamoDB, bypassing AppSync subscriptions.
+  const processingKey = transcriptions
+    .filter(t => t.mediaId && (t.mediaStatus === MEDIA_STATUS.PENDING || t.mediaStatus === MEDIA_STATUS.PROCESSING))
+    .map(t => t.mediaId as string)
+    .join(',');
+
   useEffect(() => {
-    if (!user?.userId) return;
-    const unsubscribe = subscribeToMediaChanges(
-      {},
-      (media) => applyMediaStatus(media.id, media.status)
-    );
-    return unsubscribe;
-  }, [user?.userId, applyMediaStatus]);
+    if (!processingKey) return;
+    const mediaIds = processingKey.split(',');
+
+    const pollInterval = setInterval(async () => {
+      for (const mediaId of mediaIds) {
+        try {
+          const media = await services.mediaService.getMedia(mediaId);
+          applyMediaStatus(mediaId, media.status);
+        } catch (error) {
+          console.error('Failed to poll media status:', error);
+        }
+      }
+    }, 3000);
+
+    return () => clearInterval(pollInterval);
+  }, [processingKey, applyMediaStatus]);
 
   // Handle tab switching with sync
   const handleTabSwitch = (tab: TabType) => {

--- a/src/components/list/TranscriptionsList.tsx
+++ b/src/components/list/TranscriptionsList.tsx
@@ -97,11 +97,12 @@ export const TranscriptionsList = () => {
     loadTranscriptions();
   }, [loadTranscriptions]);
 
-  // Subscribe to media status updates for the current user's files
+  // Subscribe to media status updates for the current user's files.
+  // No explicit filter needed — Amplify owner auth restricts the subscription automatically.
   useEffect(() => {
     if (!user?.userId) return;
     const unsubscribe = subscribeToMediaChanges(
-      { owner: user.userId },
+      {},
       (media) => applyMediaStatus(media.id, media.status)
     );
     return unsubscribe;

--- a/src/components/player/WaveformPlayer.test.tsx
+++ b/src/components/player/WaveformPlayer.test.tsx
@@ -212,6 +212,8 @@ describe('WaveformPlayer', () => {
         regionCursorWords: {},
         setRegionCursorWord: jest.fn(),
         setPeaks: jest.fn(),
+        mediaStatus: null,
+        setMediaStatus: jest.fn(),
       };
       return selector(state);
     });
@@ -691,6 +693,8 @@ describe('WaveformPlayer', () => {
         regionCursorWords: {},
         setRegionCursorWord: jest.fn(),
         setPeaks: jest.fn(),
+        mediaStatus: null,
+        setMediaStatus: jest.fn(),
       };
       
       mockUseEditorStore.mockImplementation((selector) => selector(mockStateWithNoEdit));
@@ -821,6 +825,8 @@ describe('WaveformPlayer', () => {
         regionCursorWords: {},
         setRegionCursorWord: jest.fn(),
         setPeaks: jest.fn(),
+        mediaStatus: null,
+        setMediaStatus: jest.fn(),
         };
         return selector(state);
       });

--- a/src/components/upload/UploadForm.tsx
+++ b/src/components/upload/UploadForm.tsx
@@ -44,8 +44,7 @@ export const UploadForm = () => {
 
       const result = await useCase.execute();
 
-      console.log('Transcription created:', result.transcription);
-      navigate('/transcribe-list');
+      navigate(`/transcribe-edit/${result.transcriptionId}`);
     } catch (error) {
       console.error('Error creating transcription:', error);
       // TODO: Show error message to user

--- a/src/components/upload/UploadForm.tsx
+++ b/src/components/upload/UploadForm.tsx
@@ -42,9 +42,9 @@ export const UploadForm = () => {
         onProgress: handleProgressUpdate,
       });
 
-      const result = await useCase.execute();
+      await useCase.execute();
 
-      navigate(`/transcribe-edit/${result.transcriptionId}`);
+      navigate('/transcribe-list');
     } catch (error) {
       console.error('Error creating transcription:', error);
       // TODO: Show error message to user

--- a/src/hooks/useLoadTranscription.test.ts
+++ b/src/hooks/useLoadTranscription.test.ts
@@ -19,7 +19,7 @@ jest.mock('../stores/useEditorStore');
 
 describe('useLoadTranscription', () => {
   // Mock implementations
-  const mockExecute = jest.fn();
+  const mockExecute = jest.fn().mockResolvedValue(undefined);
   const mockStore = {
     setFullTranscriptionData: jest.fn(),
     cleanup: jest.fn(),
@@ -27,7 +27,8 @@ describe('useLoadTranscription', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+    mockExecute.mockResolvedValue(undefined);
+
     // Mock LoadTranscription constructor and methods
     (LoadTranscription as jest.MockedClass<typeof LoadTranscription>).mockImplementation(() => ({
       execute: mockExecute,

--- a/src/hooks/useLoadTranscription.ts
+++ b/src/hooks/useLoadTranscription.ts
@@ -18,6 +18,8 @@ export const useLoadTranscription = (transcriptionId: string): void => {
       store,
     });
 
-    useCase.execute()
+    useCase.execute().catch((error: Error) => {
+      console.error('Failed to load transcription:', error);
+    });
   }
-}; 
+};

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -16,6 +16,9 @@ import { TranscriptionModel, type IssueType, ISSUE_TYPE_VALUES } from '../servic
 
 import { browserService } from '../services/browserService';
 import { wavesurferService } from '../services/wavesurferService';
+import { subscribeToMediaChanges, MEDIA_STATUS } from '../services/mediaService';
+import { LoadTranscription } from '../use-cases/load-transcription';
+import { services } from '../services';
 
 import { WaveformPlayer } from '../components/player/WaveformPlayer';
 import { RegionList } from '../components/regions/RegionList';
@@ -173,6 +176,8 @@ export const EditorPage = () => {
   // Editor store selectors
   const transcription = useEditorStore((state) => state.transcription);
   const accessDenied = useEditorStore((state) => state.accessDenied);
+  const mediaStatus = useEditorStore((state) => state.mediaStatus);
+  const setMediaStatus = useEditorStore((state) => state.setMediaStatus);
   const user = useAuthStore((state) => state.user);
   
   // Hooks for settings functionality
@@ -314,6 +319,26 @@ export const EditorPage = () => {
     };
   }, []);
 
+  // Live auto-load: when media finishes processing, reload the transcription automatically
+  useEffect(() => {
+    const mediaId = transcription?.mediaId;
+    if (!mediaId || !mediaStatus || mediaStatus === MEDIA_STATUS.ERROR) return;
+
+    const unsubscribe = subscribeToMediaChanges({ id: mediaId }, (updatedMedia) => {
+      if (updatedMedia.status === MEDIA_STATUS.READY) {
+        const store = useEditorStore.getState();
+        const useCase = new LoadTranscription({ transcriptionId: transcriptionId!, services, store });
+        useCase.execute().catch((error: Error) => console.error('Auto-load after media ready failed:', error));
+        unsubscribe();
+      } else if (updatedMedia.status === MEDIA_STATUS.ERROR) {
+        setMediaStatus(MEDIA_STATUS.ERROR);
+        unsubscribe();
+      }
+    });
+
+    return unsubscribe;
+  }, [transcriptionId, mediaStatus, setMediaStatus, transcription]);
+
   const isVideo = transcription?.isVideo ?? false
 
   return (
@@ -330,7 +355,28 @@ export const EditorPage = () => {
         </div>
       )}
 
-      {(transcription) && (
+      {/* Media Processing Overlay */}
+      {(transcription && mediaStatus && mediaStatus !== MEDIA_STATUS.READY && mediaStatus !== MEDIA_STATUS.ERROR) && (
+        <div className="absolute inset-0 bg-white flex flex-col items-center justify-center z-10" data-testid="media-processing-overlay">
+          <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+            <div className="w-10 h-10 border-4 border-gray-300 border-t-ki-blue rounded-full animate-spin mb-4"></div>
+            <p className="text-gray-700 font-medium mb-1">{transcription.title}</p>
+            <p className="text-gray-500 text-sm">This media is still being processed. The editor will load automatically when ready.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Media Error Overlay */}
+      {(transcription && mediaStatus === MEDIA_STATUS.ERROR) && (
+        <div className="absolute inset-0 bg-white flex flex-col items-center justify-center z-10" data-testid="media-error-overlay">
+          <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+            <p className="text-gray-700 font-medium mb-1">{transcription.title}</p>
+            <p className="text-red-600 text-sm">Media processing failed. Please try uploading the file again.</p>
+          </div>
+        </div>
+      )}
+
+      {(transcription && !mediaStatus) && (
         <>
         {/* Waveform/Video Player Section */}
         <div className="flex-shrink-0 bg-gray-100 border-b border-gray-300">

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -16,7 +16,7 @@ import { TranscriptionModel, type IssueType, ISSUE_TYPE_VALUES } from '../servic
 
 import { browserService } from '../services/browserService';
 import { wavesurferService } from '../services/wavesurferService';
-import { subscribeToMediaChanges, MEDIA_STATUS } from '../services/mediaService';
+import { MEDIA_STATUS } from '../services/mediaService';
 import { LoadTranscription } from '../use-cases/load-transcription';
 import { services } from '../services';
 
@@ -319,24 +319,29 @@ export const EditorPage = () => {
     };
   }, []);
 
-  // Live auto-load: when media finishes processing, reload the transcription automatically
+  // Poll media status while processing — Lambda writes directly to DynamoDB, bypassing AppSync subscriptions
   useEffect(() => {
     const mediaId = transcription?.mediaId;
     if (!mediaId || !mediaStatus || mediaStatus === MEDIA_STATUS.ERROR) return;
 
-    const unsubscribe = subscribeToMediaChanges({ id: mediaId }, (updatedMedia) => {
-      if (updatedMedia.status === MEDIA_STATUS.READY) {
-        const store = useEditorStore.getState();
-        const useCase = new LoadTranscription({ transcriptionId: transcriptionId!, services, store });
-        useCase.execute().catch((error: Error) => console.error('Auto-load after media ready failed:', error));
-        unsubscribe();
-      } else if (updatedMedia.status === MEDIA_STATUS.ERROR) {
-        setMediaStatus(MEDIA_STATUS.ERROR);
-        unsubscribe();
+    const pollInterval = setInterval(async () => {
+      try {
+        const media = await services.mediaService.getMedia(mediaId);
+        if (media.status === MEDIA_STATUS.READY) {
+          clearInterval(pollInterval);
+          const store = useEditorStore.getState();
+          const useCase = new LoadTranscription({ transcriptionId: transcriptionId!, services, store });
+          useCase.execute().catch((error: Error) => console.error('Auto-load after media ready failed:', error));
+        } else if (media.status === MEDIA_STATUS.ERROR) {
+          clearInterval(pollInterval);
+          setMediaStatus(MEDIA_STATUS.ERROR);
+        }
+      } catch (error) {
+        console.error('Failed to poll media status:', error);
       }
-    });
+    }, 3000);
 
-    return unsubscribe;
+    return () => clearInterval(pollInterval);
   }, [transcriptionId, mediaStatus, setMediaStatus, transcription]);
 
   const isVideo = transcription?.isVideo ?? false

--- a/src/services/adt.ts
+++ b/src/services/adt.ts
@@ -10,6 +10,7 @@ export interface TranscriptionData {
   issueCount?: number;
   source?: string;
   mediaId?: string;
+  media?: { status?: string } | null;
   coverage?: number;
   isPrivate?: boolean;
   publicIssues?: boolean;
@@ -239,6 +240,7 @@ export class TranscriptionModel {
   public type: string;
   public source: string;
   public mediaId?: string;
+  public mediaStatus?: string;
   public coverage: number;
   public isPrivate: boolean;
   public publicIssues: boolean;
@@ -259,7 +261,7 @@ export class TranscriptionModel {
     if (!data.id) {
       throw new Error('TranscriptionModel constructor: data.id is required');
     }
-    
+
     this.id = data.id;
     this.data = {
       ...data,
@@ -274,6 +276,7 @@ export class TranscriptionModel {
     // this.issues = Number(data.issues) || 0;
     this.source = data.source ?? '';
     this.mediaId = data.mediaId;
+    this.mediaStatus = data.media?.status ?? undefined;
     this.coverage = data.coverage || 0;
     this.isPrivate = data.isPrivate ?? true;
     this.publicIssues = data.publicIssues ?? false;

--- a/src/services/custom-queries.ts
+++ b/src/services/custom-queries.ts
@@ -1,6 +1,68 @@
 // Custom GraphQL queries for services
 
-// Custom query for compound GSI (author + dateLastUpdated)
+// Custom query for simple author GSI — includes media status for processing indicator
+export const transcriptionsByAuthorWithMedia = /* GraphQL */ `
+  query TranscriptionsByAuthor(
+    $author: String!
+    $sortDirection: ModelSortDirection
+    $filter: ModelTranscriptionFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    transcriptionsByAuthor(
+      author: $author
+      sortDirection: $sortDirection
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        author
+        authorFriendly
+        coverage
+        dateLastUpdated
+        userLastUpdated
+        length
+        issues
+        comments
+        commentCount
+        regionCount
+        issueCount
+        tags
+        source
+        mediaId
+        media {
+          id
+          status
+        }
+        index
+        lang
+        title
+        type
+        isPrivate
+        isPublished
+        publicIssues
+        disableAnalyzer
+        editors
+        viewers
+        editorGroups
+        viewerGroups
+        createdAt
+        updatedAt
+        _version
+        _deleted
+        _lastChangedAt
+        __typename
+      }
+      nextToken
+      startedAt
+      __typename
+    }
+  }
+`;
+
+// Custom query for compound GSI (author + dateLastUpdated) — includes media status
 export const transcriptionsByAuthorDate = /* GraphQL */ `
   query TranscriptionsByAuthorDate(
     $author: String!
@@ -33,6 +95,11 @@ export const transcriptionsByAuthorDate = /* GraphQL */ `
         issueCount
         tags
         source
+        mediaId
+        media {
+          id
+          status
+        }
         index
         lang
         title

--- a/src/services/mediaService.test.ts
+++ b/src/services/mediaService.test.ts
@@ -1,4 +1,4 @@
-import { createMedia, getMedia, deleteMedia, __resetClient } from './mediaService';
+import { createMedia, getMedia, deleteMedia, subscribeToMediaChanges, __resetClient } from './mediaService';
 
 jest.mock('aws-amplify/api', () => ({
   generateClient: jest.fn(),
@@ -15,6 +15,10 @@ jest.mock('../graphql/mutations.js', () => ({
 
 jest.mock('../graphql/queries.js', () => ({
   getMedia: 'mock-get-media-query',
+}));
+
+jest.mock('../graphql/subscriptions.js', () => ({
+  onUpdateMedia: 'mock-on-update-media-subscription',
 }));
 
 import { generateClient } from 'aws-amplify/api';
@@ -203,6 +207,70 @@ describe('mediaService', () => {
       await deleteMedia('media-123');
 
       expect(mockGraphql).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('subscribeToMediaChanges', () => {
+    let mockUnsubscribe: jest.Mock;
+    let mockSubscribe: jest.Mock;
+
+    beforeEach(() => {
+      mockUnsubscribe = jest.fn();
+      mockSubscribe = jest.fn().mockReturnValue({ unsubscribe: mockUnsubscribe });
+      mockGraphql.mockReturnValue({ subscribe: mockSubscribe });
+    });
+
+    it('should subscribe with owner filter and call callback on update', () => {
+      const callback = jest.fn();
+      subscribeToMediaChanges({ owner: 'user-abc' }, callback);
+
+      expect(mockGraphql).toHaveBeenCalledWith({
+        query: 'mock-on-update-media-subscription',
+        variables: { filter: { owner: { eq: 'user-abc' } } },
+      });
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ next: expect.any(Function), error: expect.any(Function) })
+      );
+    });
+
+    it('should subscribe with id filter when given an id', () => {
+      const callback = jest.fn();
+      subscribeToMediaChanges({ id: 'media-xyz' }, callback);
+
+      expect(mockGraphql).toHaveBeenCalledWith({
+        query: 'mock-on-update-media-subscription',
+        variables: { filter: { id: { eq: 'media-xyz' } } },
+      });
+    });
+
+    it('should invoke callback when media update arrives', () => {
+      const callback = jest.fn();
+      subscribeToMediaChanges({ owner: 'user-abc' }, callback);
+
+      const nextFn = mockSubscribe.mock.calls[0][0].next;
+      const updatedMedia = { id: 'media-1', status: 'READY', _deleted: false };
+      nextFn({ data: { onUpdateMedia: updatedMedia } });
+
+      expect(callback).toHaveBeenCalledWith(updatedMedia);
+    });
+
+    it('should not invoke callback when media is deleted', () => {
+      const callback = jest.fn();
+      subscribeToMediaChanges({ owner: 'user-abc' }, callback);
+
+      const nextFn = mockSubscribe.mock.calls[0][0].next;
+      nextFn({ data: { onUpdateMedia: { id: 'media-1', status: 'READY', _deleted: true } } });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should return unsubscribe function that calls unsubscribe on subscription', () => {
+      const callback = jest.fn();
+      const unsubscribe = subscribeToMediaChanges({ owner: 'user-abc' }, callback);
+
+      unsubscribe();
+
+      expect(mockUnsubscribe).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/mediaService.test.ts
+++ b/src/services/mediaService.test.ts
@@ -220,13 +220,13 @@ describe('mediaService', () => {
       mockGraphql.mockReturnValue({ subscribe: mockSubscribe });
     });
 
-    it('should subscribe with owner filter and call callback on update', () => {
+    it('should subscribe with no filter when no id given (owner auth restricts automatically)', () => {
       const callback = jest.fn();
-      subscribeToMediaChanges({ owner: 'user-abc' }, callback);
+      subscribeToMediaChanges({}, callback);
 
       expect(mockGraphql).toHaveBeenCalledWith({
         query: 'mock-on-update-media-subscription',
-        variables: { filter: { owner: { eq: 'user-abc' } } },
+        variables: {},
       });
       expect(mockSubscribe).toHaveBeenCalledWith(
         expect.objectContaining({ next: expect.any(Function), error: expect.any(Function) })
@@ -245,7 +245,7 @@ describe('mediaService', () => {
 
     it('should invoke callback when media update arrives', () => {
       const callback = jest.fn();
-      subscribeToMediaChanges({ owner: 'user-abc' }, callback);
+      subscribeToMediaChanges({}, callback);
 
       const nextFn = mockSubscribe.mock.calls[0][0].next;
       const updatedMedia = { id: 'media-1', status: 'READY', _deleted: false };
@@ -256,7 +256,7 @@ describe('mediaService', () => {
 
     it('should not invoke callback when media is deleted', () => {
       const callback = jest.fn();
-      subscribeToMediaChanges({ owner: 'user-abc' }, callback);
+      subscribeToMediaChanges({}, callback);
 
       const nextFn = mockSubscribe.mock.calls[0][0].next;
       nextFn({ data: { onUpdateMedia: { id: 'media-1', status: 'READY', _deleted: true } } });
@@ -266,7 +266,7 @@ describe('mediaService', () => {
 
     it('should return unsubscribe function that calls unsubscribe on subscription', () => {
       const callback = jest.fn();
-      const unsubscribe = subscribeToMediaChanges({ owner: 'user-abc' }, callback);
+      const unsubscribe = subscribeToMediaChanges({}, callback);
 
       unsubscribe();
 

--- a/src/services/mediaService.ts
+++ b/src/services/mediaService.ts
@@ -109,7 +109,6 @@ export const deleteMedia = async (id: string): Promise<void> => {
 };
 
 export interface SubscribeToMediaChangesFilter {
-  owner?: string;
   id?: string;
 }
 
@@ -117,16 +116,16 @@ export const subscribeToMediaChanges = (
   filter: SubscribeToMediaChangesFilter,
   callback: (media: MediaData) => void
 ): (() => void) => {
-  const gqlFilter: Record<string, unknown> = {};
-  if (filter.owner) gqlFilter['owner'] = { eq: filter.owner };
-  if (filter.id) gqlFilter['id'] = { eq: filter.id };
+  // owner is an Amplify auth field — AppSync restricts by owner automatically via $owner.
+  // Only id can be used as a subscription filter field.
+  const variables = filter.id ? { filter: { id: { eq: filter.id } } } : {};
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let subscription: any = null;
   try {
     subscription = (getClient().graphql({
       query: onUpdateMedia,
-      variables: Object.keys(gqlFilter).length > 0 ? { filter: gqlFilter } : {},
+      variables,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any).subscribe({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/services/mediaService.ts
+++ b/src/services/mediaService.ts
@@ -6,7 +6,19 @@ import { createMedia as createMediaMutation, deleteMedia as deleteMediaMutation 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { getMedia as getMediaQuery } from '../graphql/queries.js';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { onUpdateMedia } from '../graphql/subscriptions.js';
 import type { GraphQLClient } from '../types/shared';
+
+export const MEDIA_STATUS = {
+  PENDING: 'PENDING',
+  PROCESSING: 'PROCESSING',
+  READY: 'READY',
+  ERROR: 'ERROR',
+} as const;
+
+export type MediaStatus = typeof MEDIA_STATUS[keyof typeof MEDIA_STATUS];
 
 let client: GraphQLClient | null = null;
 const getClient = (): GraphQLClient => {
@@ -94,4 +106,48 @@ export const deleteMedia = async (id: string): Promise<void> => {
     variables: { input: { id, _version: media._version } },
     authMode: 'userPool',
   });
+};
+
+export interface SubscribeToMediaChangesFilter {
+  owner?: string;
+  id?: string;
+}
+
+export const subscribeToMediaChanges = (
+  filter: SubscribeToMediaChangesFilter,
+  callback: (media: MediaData) => void
+): (() => void) => {
+  const gqlFilter: Record<string, unknown> = {};
+  if (filter.owner) gqlFilter['owner'] = { eq: filter.owner };
+  if (filter.id) gqlFilter['id'] = { eq: filter.id };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let subscription: any = null;
+  try {
+    subscription = (getClient().graphql({
+      query: onUpdateMedia,
+      variables: Object.keys(gqlFilter).length > 0 ? { filter: gqlFilter } : {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any).subscribe({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      next: (result: any) => {
+        const media = result.data?.onUpdateMedia;
+        if (media && !media._deleted) {
+          callback(media as MediaData);
+        }
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      error: (error: any) => console.error('Media subscription error:', error),
+    });
+  } catch (error) {
+    console.error('Failed to establish media subscription:', error);
+  }
+
+  return () => {
+    try {
+      subscription?.unsubscribe();
+    } catch (error) {
+      console.error('Error unsubscribing from media changes:', error);
+    }
+  };
 };

--- a/src/services/transcriptionService.test.ts
+++ b/src/services/transcriptionService.test.ts
@@ -189,7 +189,7 @@ describe('TranscriptionService', () => {
       const result = await loadInFull(mockTranscriptionId);
       
       expect(result).not.toBe(false);
-      if (result !== false) {
+      if (result !== false && !('processing' in result)) {
         expect(result.peaks).toEqual([10, 20, 30]);
       }
     });
@@ -200,11 +200,11 @@ describe('TranscriptionService', () => {
         ok: true,
         json: jest.fn().mockResolvedValue(peaksDirectArray),
       });
-      
+
       const result = await loadInFull(mockTranscriptionId);
-      
+
       expect(result).not.toBe(false);
-      if (result !== false) {
+      if (result !== false && !('processing' in result)) {
         expect(result.peaks).toEqual([40, 50, 60]);
       }
     });
@@ -271,10 +271,11 @@ describe('TranscriptionService', () => {
       await expect(loadInFull(mockTranscriptionId)).rejects.toThrow('Issue loading failed');
     });
 
-    it('should route to new pipeline when source is absent', async () => {
+    it('should route to new pipeline when source is absent and media is READY', async () => {
       const mediaService = require('./mediaService');
       (mediaService.getMedia as jest.Mock).mockResolvedValue({
         id: 'media-1',
+        status: 'READY',
         renditionKey: 'public/renditions/u/media-1.mp3',
         peaksKey: 'public/peaks/u/media-1.json',
       });
@@ -297,6 +298,97 @@ describe('TranscriptionService', () => {
       const result = await loadInFull(mockTranscriptionId);
       expect(mediaService.getMedia).toHaveBeenCalledWith('media-1');
       expect(result).not.toBe(false);
+      expect('processing' in (result as object)).toBe(false);
+    });
+
+    // Regression tests for mid-processing open (previously caused infinite retry loop)
+    it('should return processing result when media status is PENDING', async () => {
+      const mediaService = require('./mediaService');
+      (mediaService.getMedia as jest.Mock).mockResolvedValue({
+        id: 'media-1',
+        status: 'PENDING',
+        renditionKey: null,
+        peaksKey: null,
+      });
+
+      mockGraphqlClient.graphql.mockResolvedValue({
+        data: {
+          getTranscription: { ...mockRawTranscription, source: null, mediaId: 'media-1' },
+        },
+      });
+
+      (TranscriptionModel as jest.MockedClass<typeof TranscriptionModel>).mockImplementation(
+        (data: any) => ({
+          ...data,
+          source: data.source ?? null,
+          mediaId: data.mediaId,
+          setAccessLevel: jest.fn(),
+        }) as any
+      );
+
+      const result = await loadInFull(mockTranscriptionId);
+      expect(result).not.toBe(false);
+      expect(result).toMatchObject({ processing: true, mediaId: 'media-1', mediaStatus: 'PENDING' });
+      // Must not attempt to fetch peaks (would previously cause 11-retry loop)
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return processing result when media status is PROCESSING', async () => {
+      const mediaService = require('./mediaService');
+      (mediaService.getMedia as jest.Mock).mockResolvedValue({
+        id: 'media-2',
+        status: 'PROCESSING',
+        renditionKey: null,
+        peaksKey: null,
+      });
+
+      mockGraphqlClient.graphql.mockResolvedValue({
+        data: {
+          getTranscription: { ...mockRawTranscription, source: null, mediaId: 'media-2' },
+        },
+      });
+
+      (TranscriptionModel as jest.MockedClass<typeof TranscriptionModel>).mockImplementation(
+        (data: any) => ({
+          ...data,
+          source: data.source ?? null,
+          mediaId: data.mediaId,
+          setAccessLevel: jest.fn(),
+        }) as any
+      );
+
+      const result = await loadInFull(mockTranscriptionId);
+      expect(result).toMatchObject({ processing: true, mediaId: 'media-2', mediaStatus: 'PROCESSING' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return processing result when media status is ERROR', async () => {
+      const mediaService = require('./mediaService');
+      (mediaService.getMedia as jest.Mock).mockResolvedValue({
+        id: 'media-3',
+        status: 'ERROR',
+        renditionKey: null,
+        peaksKey: null,
+      });
+
+      mockGraphqlClient.graphql.mockResolvedValue({
+        data: {
+          getTranscription: { ...mockRawTranscription, source: null, mediaId: 'media-3' },
+        },
+      });
+
+      (TranscriptionModel as jest.MockedClass<typeof TranscriptionModel>).mockImplementation(
+        (data: any) => ({
+          ...data,
+          source: data.source ?? null,
+          mediaId: data.mediaId,
+          setAccessLevel: jest.fn(),
+        }) as any
+      );
+
+      const result = await loadInFull(mockTranscriptionId);
+      expect(result).toMatchObject({ processing: true, mediaId: 'media-3', mediaStatus: 'ERROR' });
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('should throw when source is absent and getMedia fails', async () => {
@@ -346,9 +438,9 @@ describe('TranscriptionService', () => {
 
     it('should return peaks as array of numbers when access is granted', async () => {
       const result = await loadInFull(mockTranscriptionId);
-      
+
       expect(result).not.toBe(false);
-      if (result !== false) {
+      if (result !== false && !('processing' in result)) {
         expect(Array.isArray(result.peaks)).toBe(true);
         expect(result.peaks).toEqual(mockPeaksData);
       }
@@ -356,9 +448,9 @@ describe('TranscriptionService', () => {
 
     it('should return regions as array when access is granted', async () => {
       const result = await loadInFull(mockTranscriptionId);
-      
+
       expect(result).not.toBe(false);
-      if (result !== false) {
+      if (result !== false && !('processing' in result)) {
         expect(Array.isArray(result.regions)).toBe(true);
         expect(result.regions).toBe(mockRegions);
       }
@@ -366,9 +458,9 @@ describe('TranscriptionService', () => {
 
     it('should return issues as array when access is granted', async () => {
       const result = await loadInFull(mockTranscriptionId);
-      
+
       expect(result).not.toBe(false);
-      if (result !== false) {
+      if (result !== false && !('processing' in result)) {
         expect(Array.isArray(result.issues)).toBe(true);
         expect(result.issues).toBe(mockIssues);
       }
@@ -420,7 +512,7 @@ describe('TranscriptionService', () => {
       const result = await loadInFull(mockTranscriptionId);
       
       expect(result).not.toBe(false);
-      if (result !== false) {
+      if (result !== false && !('processing' in result)) {
         expect(result.regions).toEqual([]);
         expect(result.issues).toEqual([]);
       }

--- a/src/services/transcriptionService.ts
+++ b/src/services/transcriptionService.ts
@@ -3,9 +3,9 @@ import { getUrl, remove } from 'aws-amplify/storage';
 import { fetchAuthSession } from 'aws-amplify/auth';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - GraphQL queries are generated as JS files
-import { getTranscription, transcriptionsByAuthor } from '../graphql/queries.js';
+import { getTranscription } from '../graphql/queries.js';
 
-import { transcriptionsByAuthorDate } from './custom-queries';
+import { transcriptionsByAuthorDate, transcriptionsByAuthorWithMedia } from './custom-queries';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - GraphQL mutations are generated as JS files
 import { createTranscription as createTranscriptionMutation, updateTranscription as updateTranscriptionMutation, deleteTranscription as deleteTranscriptionMutation } from '../graphql/mutations.js';
@@ -20,16 +20,19 @@ import { getMyInvites } from './inviteService';
 import { getMedia } from './mediaService';
 import { awsConfigService } from './awsConfigService';
 
-import { 
-  type GraphQLClient, 
-  type GraphQLResponse, 
+import {
+  type GraphQLClient,
+  type GraphQLResponse,
   type GetTranscriptionResponse,
   type CreateTranscriptionResponse,
   type UpdateTranscriptionResponse,
   type DeleteTranscriptionResponse,
-  type TranscriptionData as SharedTranscriptionData, 
+  type TranscriptionData as SharedTranscriptionData,
   type LoadTranscriptionResult,
+  type LoadTranscriptionProcessingResult,
 } from '../types/shared';
+
+import { MEDIA_STATUS } from './mediaService';
 
 // Sync state management
 let currentSyncOperation: Promise<TranscriptionModel[]> | null = null;
@@ -436,7 +439,7 @@ const fetchPeaksDataByKey = async (
  * @param transcriptionId The ID of the transcription to load.
  * @returns An object containing the transcription, regions, and issues, or false if access denied.
  */
-export const loadInFull = async (transcriptionId: string): Promise<false | LoadTranscriptionResult> => {
+export const loadInFull = async (transcriptionId: string): Promise<false | LoadTranscriptionResult | LoadTranscriptionProcessingResult> => {
   if (!transcriptionId) {
     throw new Error('transcriptionId is required');
   }
@@ -475,6 +478,14 @@ export const loadInFull = async (transcriptionId: string): Promise<false | LoadT
   } else {
     // New pipeline: fetch Media record and derive source + peaks from it
     const media = await getMedia(transcription.mediaId!);
+    if (media.status !== MEDIA_STATUS.READY) {
+      return {
+        processing: true,
+        transcription,
+        mediaId: media.id,
+        mediaStatus: media.status,
+      };
+    }
     const bucket = awsConfigService.getUserFilesBucket();
     transcription.source = `https://${bucket}.s3.amazonaws.com/${media.renditionKey}`;
     const result = await fetchPeaksDataByKey(media.peaksKey!);
@@ -512,7 +523,7 @@ const loadOwnedTranscriptions = async (userId: string): Promise<TranscriptionMod
     
     do {
       const graphqlResult = await getClient().graphql({
-        query: transcriptionsByAuthor,
+        query: transcriptionsByAuthorWithMedia,
         variables: {
           author: userId,
           limit: 50,
@@ -520,13 +531,13 @@ const loadOwnedTranscriptions = async (userId: string): Promise<TranscriptionMod
         }
       });
 
-      const response = graphqlResult as { 
-        data: { 
+      const response = graphqlResult as {
+        data: {
           transcriptionsByAuthor: {
             items: SharedTranscriptionData[];
             nextToken?: string;
           }
-        } 
+        }
       };
       const page = response.data?.transcriptionsByAuthor;
       

--- a/src/services/transcriptionService.ts
+++ b/src/services/transcriptionService.ts
@@ -1107,7 +1107,12 @@ export const create = async (data: CreateTranscriptionData): Promise<SharedTrans
       await transcriptionStorage.setLastSyncedAt(user.userId, new Date().toISOString());
       
       try {
-        const model = new TranscriptionModel(created as unknown as ADTTranscriptionData);
+        // AppSync resolves @belongsTo as null in mutation responses — inject the
+        // known PENDING status so the list shows the processing indicator immediately.
+        const createdWithMedia = created.mediaId && !created.media
+          ? { ...created, media: { status: 'PENDING' } }
+          : created;
+        const model = new TranscriptionModel(createdWithMedia as unknown as ADTTranscriptionData);
         model.setAccessLevel(user.userId);
         await transcriptionStorage.storeTranscriptions([model]);
         console.debug('✅ Optimistically added new transcription to cache');

--- a/src/stores/useEditorStore.ts
+++ b/src/stores/useEditorStore.ts
@@ -36,6 +36,7 @@ interface EditorState {
   showExpiredCredentialsDialog: boolean;
   accessDenied: boolean;
   canEdit: boolean;
+  mediaStatus: string | null;
 
   // Regions state
   regions: RegionData[];
@@ -83,6 +84,7 @@ interface EditorState {
   // Actions
   setFullTranscriptionData: (data: EditorDataPayload, selectedRegionId?: string | null) => void;
   setAccessDenied: (denied: boolean) => void;
+  setMediaStatus: (status: string | null) => void;
   setWavesurferError: (error: string | null) => void;
   setShowExpiredCredentialsDialog: (show: boolean) => void;
   cleanup: () => void;
@@ -179,6 +181,7 @@ export const useEditorStore = create<EditorState>()(
       showExpiredCredentialsDialog: false,
       accessDenied: false,
       canEdit: false,
+      mediaStatus: null,
       regions: [],
       regionMap: {},
       regionVersions: {},
@@ -328,6 +331,10 @@ export const useEditorStore = create<EditorState>()(
         set({ accessDenied: denied });
       },
 
+      setMediaStatus: (status) => {
+        set({ mediaStatus: status });
+      },
+
       setWavesurferError: (error: string | null) => {
         set({ wavesurferError: error });
       },
@@ -351,6 +358,7 @@ export const useEditorStore = create<EditorState>()(
           transcription: null,
           peaks: null,
           accessDenied: false,
+          mediaStatus: null,
           regions: [],
           regionMap: {},
           regionVersions: {},

--- a/src/stores/useTranscriptionsStore.ts
+++ b/src/stores/useTranscriptionsStore.ts
@@ -34,6 +34,9 @@ interface TranscriptionsState {
   updateCacheStats: (stats: CacheStats) => void;
   mergeTranscriptions: (newTranscriptions: TranscriptionModel[]) => void;
   
+  // Media status updates
+  applyMediaStatus: (mediaId: string, status: string) => void;
+
   // Tab-specific sync actions
   setOwnedSyncStatus: (status: 'synced' | 'syncing' | null) => void;
   setSharedSyncStatus: (status: 'synced' | 'syncing' | null) => void;
@@ -103,6 +106,17 @@ export const useTranscriptionsStore = create<TranscriptionsState>()(
         set({ transcriptions: mergedTranscriptions });
       },
       
+      // Media status updates — find the matching transcription and update its mediaStatus
+      applyMediaStatus: (mediaId: string, status: string) => {
+        const { transcriptions } = get();
+        const updated = transcriptions.map(t => {
+          if (t.mediaId !== mediaId) return t;
+          t.mediaStatus = status;
+          return t;
+        });
+        set({ transcriptions: updated });
+      },
+
       // Tab-specific sync actions
       setOwnedSyncStatus: (ownedSyncStatus: 'synced' | 'syncing' | null) => {
         set({ ownedSyncStatus });

--- a/src/stores/useTranscriptionsStore.ts
+++ b/src/stores/useTranscriptionsStore.ts
@@ -106,6 +106,11 @@ export const useTranscriptionsStore = create<TranscriptionsState>()(
         set({ transcriptions: mergedTranscriptions });
       },
       
+      removeTranscription: (transcriptionId: string) => {
+        const { transcriptions } = get();
+        set({ transcriptions: transcriptions.filter(t => t.id !== transcriptionId) });
+      },
+
       // Media status updates — find the matching transcription and update its mediaStatus
       applyMediaStatus: (mediaId: string, status: string) => {
         const { transcriptions } = get();

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -120,6 +120,13 @@ export type LoadTranscriptionResult = {
   comments: CommentData[];
 };
 
+export type LoadTranscriptionProcessingResult = {
+  processing: true;
+  transcription: TranscriptionModel;
+  mediaId: string;
+  mediaStatus: string;
+};
+
 export interface User {
   username: string;
   email?: string;
@@ -157,6 +164,7 @@ export interface StoreWithTranscriptionData {
   setCanEdit: (canEdit: boolean) => void;
   addKnownWords: (words: string[]) => void;
   setTranscription: (transcription: TranscriptionData) => void;
+  setMediaStatus: (status: string | null) => void;
   transcription: TranscriptionData | null;
 }
 

--- a/src/use-cases/load-transcription.test.ts
+++ b/src/use-cases/load-transcription.test.ts
@@ -38,6 +38,8 @@ describe('LoadTranscription', () => {
     addKnownWords: jest.fn(),
     setAccessDenied: jest.fn(),
     setCanEdit: jest.fn(),
+    setTranscription: jest.fn(),
+    setMediaStatus: jest.fn(),
   };
   const mockTranscriptionData = {
     transcription: {
@@ -245,11 +247,74 @@ describe('LoadTranscription', () => {
 
     it('should set canEdit to false when user cannot edit', async () => {
       (services.userService.canEditTranscription as jest.Mock).mockReturnValue(false);
-      
+
       await useCase.execute();
-      
+
       expect(services.userService.canEditTranscription).toHaveBeenCalledWith(mockTranscriptionData.transcription);
       expect(mockStore.setCanEdit).toHaveBeenCalledWith(false);
+    });
+
+    describe('media processing variant', () => {
+      const mockProcessingTranscription = {
+        id: mockTranscriptionId,
+        title: 'Processing Transcription',
+        mediaId: 'media-1',
+      };
+
+      it('should set transcription and mediaStatus when media is PENDING', async () => {
+        (services.transcriptionService.loadInFull as jest.Mock).mockResolvedValue({
+          processing: true,
+          transcription: mockProcessingTranscription,
+          mediaId: 'media-1',
+          mediaStatus: 'PENDING',
+        });
+
+        await useCase.execute();
+
+        expect(mockStore.setTranscription).toHaveBeenCalledWith(mockProcessingTranscription);
+        expect(mockStore.setMediaStatus).toHaveBeenCalledWith('PENDING');
+      });
+
+      it('should NOT call setFullTranscriptionData when media is processing', async () => {
+        (services.transcriptionService.loadInFull as jest.Mock).mockResolvedValue({
+          processing: true,
+          transcription: mockProcessingTranscription,
+          mediaId: 'media-1',
+          mediaStatus: 'PROCESSING',
+        });
+
+        await useCase.execute();
+
+        expect(mockStore.setFullTranscriptionData).not.toHaveBeenCalled();
+      });
+
+      it('should NOT call wavesurferService.load when media is processing', async () => {
+        (services.transcriptionService.loadInFull as jest.Mock).mockResolvedValue({
+          processing: true,
+          transcription: mockProcessingTranscription,
+          mediaId: 'media-1',
+          mediaStatus: 'PENDING',
+        });
+
+        await useCase.execute();
+
+        expect(services.wavesurferService.load).not.toHaveBeenCalled();
+      });
+
+      it('should set transcription and ERROR mediaStatus when media errored', async () => {
+        (services.transcriptionService.loadInFull as jest.Mock).mockResolvedValue({
+          processing: true,
+          transcription: mockProcessingTranscription,
+          mediaId: 'media-1',
+          mediaStatus: 'ERROR',
+        });
+
+        await useCase.execute();
+
+        expect(mockStore.setTranscription).toHaveBeenCalledWith(mockProcessingTranscription);
+        expect(mockStore.setMediaStatus).toHaveBeenCalledWith('ERROR');
+        expect(services.wavesurferService.load).not.toHaveBeenCalled();
+      });
     });
 
     describe('error handling', () => {

--- a/src/use-cases/load-transcription.test.ts
+++ b/src/use-cases/load-transcription.test.ts
@@ -254,6 +254,12 @@ describe('LoadTranscription', () => {
       expect(mockStore.setCanEdit).toHaveBeenCalledWith(false);
     });
 
+    it('should clear mediaStatus when load succeeds (dismisses processing overlay)', async () => {
+      await useCase.execute();
+
+      expect(mockStore.setMediaStatus).toHaveBeenCalledWith(null);
+    });
+
     describe('media processing variant', () => {
       const mockProcessingTranscription = {
         id: mockTranscriptionId,

--- a/src/use-cases/load-transcription.ts
+++ b/src/use-cases/load-transcription.ts
@@ -40,15 +40,24 @@ export class LoadTranscription {
       this.config.store.setAccessDenied(true);
       return;
     }
-    
+
+    // Check if media is still processing (or errored) — show status UI, skip wavesurfer
+    if ('processing' in data) {
+      const canEdit = userService.canEditTranscription(data.transcription);
+      this.config.store.setCanEdit(canEdit);
+      this.config.store.setTranscription(data.transcription);
+      this.config.store.setMediaStatus(data.mediaStatus);
+      return;
+    }
+
     // Check if user can edit this transcription
     const canEdit = userService.canEditTranscription(data.transcription);
     this.config.store.setCanEdit(canEdit);
-    
+
     // Read deep-link params
     const selectedRegionId = browserService.getRegionIdFromUrl();
     const selectedIssueId = browserService.getIssueIdFromUrl?.() || null;
-    
+
     // Set transcription data in store - use null instead of undefined for consistency with tests
     this.config.store.setFullTranscriptionData(data, selectedRegionId || null);
     // Persist selected issue id in store if provided

--- a/src/use-cases/load-transcription.ts
+++ b/src/use-cases/load-transcription.ts
@@ -53,6 +53,7 @@ export class LoadTranscription {
     // Check if user can edit this transcription
     const canEdit = userService.canEditTranscription(data.transcription);
     this.config.store.setCanEdit(canEdit);
+    this.config.store.setMediaStatus(null);
 
     // Read deep-link params
     const selectedRegionId = browserService.getRegionIdFromUrl();


### PR DESCRIPTION
resolve #271

Shows feedback while a newly uploaded file is processing. The transcriptions list displays a spinner on in-progress rows and an error icon on failed ones. The editor handles being opened mid-processing gracefully and reloads automatically once the media is ready. After upload, the user is redirected straight to the editor.

### Testing
Unit tests cover the new MediaStatusIndicator component, the processing variant in loadInFull, and the load-transcription use case's processing/ready paths. Manually verified the full upload-to-editor flow.