### PR TITLE
Un-auth support page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,12 @@ import {
   Routes,
   Route,
   Navigate,
+  Outlet,
 } from 'react-router-dom';
 import { useEffect } from 'react';
 import { AuthenticatorShell } from './components/auth/AuthenticatorShell';
 import { AppLayout } from './components/layout/AppLayout';
+import { SupportLayout } from './components/layout/SupportLayout';
 import { TranscribeListPage } from './pages/TranscribeListPage';
 import { StatsPage } from './pages/StatsPage';
 import { AboutPage } from './pages/AboutPage';
@@ -32,33 +34,48 @@ function App() {
   }, [showConflictDialog]);
 
   return (
-    <AuthenticatorShell>
+    <>
       <Router>
         <Routes>
-          <Route path="/" element={<AppLayout />}>
-            <Route index element={<Navigate to="/transcribe-list" replace />} /> 
-            <Route path="transcribe-list" element={<TranscribeListPage />} />
-            <Route path="transcribe-add" element={<UploadForm />} /> 
-            <Route path="transcribe-edit/:id" element={<EditorPage />} /> 
-            <Route
-              path="transcribe-edit/:id/:regionId"
-              element={<EditorPage />}
-            />
-            <Route path="invitations" element={<InvitationsPage />} />
-            <Route path="invitations/:inviteId" element={<InvitationsPage />} />
-            <Route path="database" element={<DatabaseHomePage />} />
-            <Route path="database/lemma/:lemma" element={<DatabaseLemmaPage />} />
-            <Route path="stats" element={<StatsPage />} />
-            <Route path="about" element={<AboutPage />} />
-            <Route path="support" element={<SupportPage />} />
-            <Route path="issue-browser" element={<IssueBrowserPage />} />
-            <Route path="*" element={<NotFoundPage />} />
+          {/* Public routes — no authentication required */}
+          <Route element={<SupportLayout />}>
+            <Route path="/support" element={<SupportPage />} />
+          </Route>
+
+          {/* Authenticated routes */}
+          <Route element={<AuthenticatedShell />}>
+            <Route path="/" element={<AppLayout />}>
+              <Route index element={<Navigate to="/transcribe-list" replace />} />
+              <Route path="transcribe-list" element={<TranscribeListPage />} />
+              <Route path="transcribe-add" element={<UploadForm />} />
+              <Route path="transcribe-edit/:id" element={<EditorPage />} />
+              <Route
+                path="transcribe-edit/:id/:regionId"
+                element={<EditorPage />}
+              />
+              <Route path="invitations" element={<InvitationsPage />} />
+              <Route path="invitations/:inviteId" element={<InvitationsPage />} />
+              <Route path="database" element={<DatabaseHomePage />} />
+              <Route path="database/lemma/:lemma" element={<DatabaseLemmaPage />} />
+              <Route path="stats" element={<StatsPage />} />
+              <Route path="about" element={<AboutPage />} />
+              <Route path="issue-browser" element={<IssueBrowserPage />} />
+              <Route path="*" element={<NotFoundPage />} />
+            </Route>
           </Route>
         </Routes>
       </Router>
-      
+
       {/* Global conflict resolution dialog */}
       <ConflictDialogComponent />
+    </>
+  );
+}
+
+function AuthenticatedShell() {
+  return (
+    <AuthenticatorShell>
+      <Outlet />
     </AuthenticatorShell>
   );
 }

--- a/src/components/layout/SupportLayout.tsx
+++ b/src/components/layout/SupportLayout.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { Outlet, Link } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { getCurrentUser } from 'aws-amplify/auth';
+import { useAuthStore } from '../../stores/useAuthStore';
+
+export const SupportLayout = () => {
+  const signedIn = useAuthStore((state) => state.signedIn);
+  const setUser = useAuthStore((state) => state.setUser);
+  const [authChecked, setAuthChecked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const u = await getCurrentUser();
+        if (cancelled) return;
+        setUser({
+          username: (u.signInDetails?.loginId as string) ?? u.username,
+          userId: u.userId,
+          signInDetails: u.signInDetails,
+        });
+      } catch {
+        if (!cancelled) setUser(null);
+      } finally {
+        if (!cancelled) setAuthChecked(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setUser]);
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      <header className="fixed top-0 left-0 right-0 z-[1000] flex items-center p-4 bg-ki-blue text-white shadow-md">
+        <div className="flex-1 flex items-center gap-6">
+          <img
+            src="/logo.png"
+            alt="kiyânaw Transcribe"
+            className="w-[40px] h-[40px] rounded-[3px] border border-white"
+          />
+        </div>
+
+        <div className="absolute inset-0 flex items-center justify-center md:hidden pointer-events-none">
+          <span className="text-white font-semibold text-lg">kiyânaw</span>
+        </div>
+
+        <div className="flex items-center gap-4">
+          {authChecked &&
+            (signedIn ? (
+              <Link
+                to="/transcribe-list"
+                className="flex items-center text-white hover:text-white/80 transition-colors duration-200 text-base font-medium"
+              >
+                <ArrowLeft className="w-4 h-4 mr-1" />
+                Home
+              </Link>
+            ) : (
+              <Link
+                to="/"
+                className="text-white hover:text-white/80 transition-colors duration-200 text-base font-medium"
+              >
+                Sign in
+              </Link>
+            ))}
+        </div>
+      </header>
+
+      <main className="flex-1 mt-[72px]">
+        <Outlet />
+      </main>
+    </div>
+  );
+};

--- a/src/pages/SupportPage.tsx
+++ b/src/pages/SupportPage.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { Copy, Check, MessageCircle, Users } from 'lucide-react';
+import { useAuthStore } from '../stores/useAuthStore';
 
 export const SupportPage = () => {
   const [emailCopied, setEmailCopied] = useState(false);
+  const signedIn = useAuthStore((state) => state.signedIn);
   const supportEmail = 'support@kiyanaw.net';
   const facebookMessengerUrl = 'https://m.me/115148727058478';
   const discordInviteUrl = 'https://discord.gg/ucekEKjvWz';
@@ -87,20 +89,22 @@ export const SupportPage = () => {
             </button>
           </div>
 
-          {/* Discord */}
-          <div>
-            <h2 className="text-lg font-medium text-gray-900 mb-3">Discord Community</h2>
-            <p className="text-sm text-gray-600 mb-3">
-              Join our Discord server to connect with the community and get support from other users.
-            </p>
-            <button
-              onClick={handleDiscordClick}
-              className="w-full flex items-center justify-center p-3 bg-[#5865F2] hover:bg-[#4752C4] text-white rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[#5865F2] focus:ring-opacity-50"
-            >
-              <Users className="w-5 h-5 mr-2" />
-              <span className="font-medium">Join our Discord</span>
-            </button>
-          </div>
+          {/* Discord — only visible to signed-in users */}
+          {signedIn && (
+            <div>
+              <h2 className="text-lg font-medium text-gray-900 mb-3">Discord Community</h2>
+              <p className="text-sm text-gray-600 mb-3">
+                Join our Discord server to connect with the community and get support from other users.
+              </p>
+              <button
+                onClick={handleDiscordClick}
+                className="w-full flex items-center justify-center p-3 bg-[#5865F2] hover:bg-[#4752C4] text-white rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-[#5865F2] focus:ring-opacity-50"
+              >
+                <Users className="w-5 h-5 mr-2" />
+                <span className="font-medium">Join our Discord</span>
+              </button>
+            </div>
+          )}
 
           {/* Additional Info */}
           <div className="pt-4 border-t border-gray-200">


### PR DESCRIPTION
Puts support page _outside_ the auth wrapper so that it's more accessible. Hides the Discord link unless you're logged-in.
