### PR TITLE
Fix iPhone spatial-audio (apac) transcode failure and harden media migration

### DIFF
--- a/amplify/backend/function/processMedia/src/lib/media.js
+++ b/amplify/backend/function/processMedia/src/lib/media.js
@@ -21,6 +21,33 @@ function isVideo(mimeType, ext) {
   return VIDEO_EXTENSIONS.includes(ext.toLowerCase())
 }
 
+// Codecs that ffmpeg cannot decode (e.g. Apple spatial audio in iPhone MOVs).
+const UNDECODABLE_AUDIO_CODECS = new Set(['apac', 'none'])
+
+// Returns the audio-relative index of the first decodable audio stream, or null
+// if the file has no audio or only undecodable streams. Used to build an explicit
+// -map flag so ffmpeg doesn't auto-select a high-channel-count undecodable track.
+async function selectAudioStream(filePath) {
+  return new Promise((resolve) => {
+    const { exec } = require('child_process')
+    exec(
+      `ffprobe -v error -select_streams a -show_entries stream=codec_name -of json ${escapeShellArg(filePath)}`,
+      { maxBuffer: 1024 * 64 },
+      (error, stdout) => {
+        if (error) { resolve(null); return }
+        try {
+          const { streams } = JSON.parse(stdout)
+          if (!streams || streams.length === 0) { resolve(null); return }
+          const idx = streams.findIndex(s => s.codec_name && !UNDECODABLE_AUDIO_CODECS.has(s.codec_name))
+          resolve(idx >= 0 ? idx : null)
+        } catch {
+          resolve(null)
+        }
+      }
+    )
+  })
+}
+
 async function getDuration(filePath) {
   return new Promise((resolve, reject) => {
     const { exec } = require('child_process')
@@ -68,19 +95,26 @@ async function run({ id, originalKey, mimeType }) {
     const thumbLocalPath = audioOnly ? null : `${efsPath}/${id}-thumb.jpg`
     const thumbnailKey = audioOnly ? null : `public/thumbnails/${id}.jpg`
 
+    // Probe audio streams before transcoding. iPhones embed an undecodable Apple
+    // spatial-audio (apac) track alongside the standard AAC; without an explicit
+    // map, ffmpeg auto-selects the highest-channel-count stream and fails.
+    const audioIdx = await selectAudioStream(origLocalPath)
+    const aMap = audioIdx !== null ? `-map 0:a:${audioIdx}` : ''
+
     // 2. Transcode
     if (isLargeVideo) {
       console.log(`Media ${id} is a large video (${(fileSizeBytes / 1024 / 1024).toFixed(0)} MB) — extracting audio only`)
       await runCommand(
-        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -vn -c:a libmp3lame -b:a 192k ${escapeShellArg(renditionLocalPath)}`
+        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} ${aMap} -vn -c:a libmp3lame -b:a 192k ${escapeShellArg(renditionLocalPath)}`
       )
     } else if (video) {
+      const aCodec = aMap ? '-c:a aac -b:a 128k' : ''
       await runCommand(
-        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -vf scale=-2:720 -c:v libx264 -b:v 1500k -preset veryfast -c:a aac -b:a 128k ${escapeShellArg(renditionLocalPath)}`
+        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -map 0:v:0 ${aMap} -dn -c:v libx264 -b:v 1500k -preset veryfast -vf scale=-2:720 ${aCodec} ${escapeShellArg(renditionLocalPath)}`
       )
     } else {
       await runCommand(
-        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -vn -c:a libmp3lame -b:a 192k ${escapeShellArg(renditionLocalPath)}`
+        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} ${aMap} -vn -c:a libmp3lame -b:a 192k ${escapeShellArg(renditionLocalPath)}`
       )
     }
 

--- a/amplify/backend/function/processMedia/src/test/test-media.js
+++ b/amplify/backend/function/processMedia/src/test/test-media.js
@@ -26,7 +26,12 @@ jest.mock('fs', () => ({
 jest.mock('child_process', () => ({
   exec: jest.fn((cmd, optsOrCb, cb) => {
     const callback = typeof optsOrCb === 'function' ? optsOrCb : cb
-    callback(null, '5.0', '')
+    if (typeof cmd === 'string' && cmd.includes('-select_streams a')) {
+      // ffprobe audio selection: single decodable AAC stream by default
+      callback(null, JSON.stringify({ streams: [{ codec_name: 'aac' }] }), '')
+    } else {
+      callback(null, '5.0', '') // ffprobe duration
+    }
   }),
 }))
 
@@ -137,5 +142,22 @@ describe('media.run', () => {
 
     const errorCall = mockUpdateMediaStatus.mock.calls.find(c => c[1] === 'ERROR')
     expect(errorCall).toBeTruthy()
+  })
+
+  it('skips undecodable apac track and maps the next decodable audio stream', async () => {
+    // Simulate iPhone MOV with apac (spatial audio) first, AAC second
+    const { exec } = require('child_process')
+    exec.mockImplementationOnce((cmd, optsOrCb, cb) => {
+      const callback = typeof optsOrCb === 'function' ? optsOrCb : cb
+      callback(null, JSON.stringify({ streams: [{ codec_name: 'apac' }, { codec_name: 'aac' }] }), '')
+    })
+
+    await run({ id: 'iphone', originalKey: 'public/originals/iphone.mov', mimeType: 'video/quicktime' })
+
+    const transcodeCall = mockRunCommand.mock.calls.find(c => c[0].includes('libx264'))
+    expect(transcodeCall).toBeTruthy()
+    // apac is at audio-relative index 0; AAC is at index 1 — must map to a:1
+    expect(transcodeCall[0]).toContain('-map 0:a:1')
+    expect(transcodeCall[0]).not.toContain('-map 0:a:0')
   })
 })

--- a/scripts/create-media-for-transcriptions.js
+++ b/scripts/create-media-for-transcriptions.js
@@ -18,6 +18,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, ScanCommand, GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { fromIni } from '@aws-sdk/credential-providers';
 import { randomUUID } from 'crypto';
+import { writeFileSync } from 'fs';
 
 const CLI_ARGS = process.argv.slice(2);
 
@@ -412,6 +413,7 @@ async function main() {
 
   let successCount = 0;
   let errorCount = 0;
+  const failures = [];
 
   for (const transcription of legacy) {
     const originalKey = extractKeyFromUrl(transcription.source);
@@ -420,11 +422,17 @@ async function main() {
 
     console.log(`Processing: ${transcription.id}  "${transcription.title}"  ->  ${originalName}`);
 
-    await createMediaRecord(mediaId, transcription, originalKey, originalName);
-    await pollUntilReady(mediaId);
-    await linkTranscriptionToMedia(transcription, mediaId);
-    console.log(`  ✅ Done (mediaId: ${mediaId})`);
-    successCount++;
+    try {
+      await createMediaRecord(mediaId, transcription, originalKey, originalName);
+      await pollUntilReady(mediaId);
+      await linkTranscriptionToMedia(transcription, mediaId);
+      console.log(`  ✅ Done (mediaId: ${mediaId})`);
+      successCount++;
+    } catch (err) {
+      console.error(`  ❌ Failed: ${err.message}`);
+      errorCount++;
+      failures.push({ id: transcription.id, title: transcription.title, originalName, error: err.message });
+    }
   }
 
   // Re-scan media so newly processed records are included in backfills
@@ -433,9 +441,17 @@ async function main() {
   await backfillMediaAcls(all);
   await backfillAudioOnly(allMediaAfter);
 
+  const logPath = `migration-errors-${Date.now()}.json`;
+  if (failures.length > 0) {
+    writeFileSync(logPath, JSON.stringify(failures, null, 2));
+  }
+
   console.log('\n' + '='.repeat(80));
   console.log('Migration complete!');
   console.log(`✅ Migrated: ${successCount}`);
+  if (errorCount > 0) {
+    console.log(`❌ Errors:   ${errorCount}  (see ${logPath})`);
+  }
   console.log(`📊 Total:    ${legacy.length}`);
 }
 


### PR DESCRIPTION
iPhones record MOVs with an Apple spatial-audio track (apac codec) that ffmpeg 4.1.3 cannot decode. Without explicit stream mapping ffmpeg auto-selects the highest-channel-count audio stream, hitting apac and dying. Now probes audio streams with ffprobe before transcoding and maps the first decodable one.

Also wraps the migration's per-record loop in try/catch so a single bad file no longer aborts the full batch; failures are written to a timestamped JSON log.