### PR TITLE
Fix processMedia failures found during the media migration

### DIFF
--- a/amplify/backend/function/processMedia/src/lib/media.js
+++ b/amplify/backend/function/processMedia/src/lib/media.js
@@ -149,8 +149,11 @@ async function run({ id, originalKey, mimeType }) {
       )
     } else if (hasVideo) {
       const aCodec = aMap ? '-c:a aac -b:a 128k' : ''
+      // max_muxing_queue_size guards against "Too many packets buffered for
+      // output stream" on long, low-bitrate videos where erratic input
+      // timestamps make ffmpeg's default interleaving buffer overflow.
       await runCommand(
-        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -map 0:v:0 ${aMap} -dn -c:v libx264 -b:v 1500k -preset veryfast -vf scale=-2:720 ${aCodec} ${escapeShellArg(renditionLocalPath)}`
+        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -map 0:v:0 ${aMap} -dn -c:v libx264 -b:v 1500k -preset veryfast -vf scale=-2:720 ${aCodec} -max_muxing_queue_size 9999 ${escapeShellArg(renditionLocalPath)}`
       )
     } else {
       await runCommand(

--- a/amplify/backend/function/processMedia/src/lib/media.js
+++ b/amplify/backend/function/processMedia/src/lib/media.js
@@ -7,11 +7,15 @@ const { escapeShellArg } = require('../utils')
 
 const bucket = process.env.STORAGE_TRANSCRIPTIONS_BUCKETNAME
 
-// TODO: Large videos that exceed this threshold are extracted to audio-only
-// to avoid Lambda's 15-minute timeout. The proper fix is to offload
-// transcoding for large files to a Fargate task so they get a proper
-// compressed video rendition.
-const LARGE_VIDEO_BYTES = 75 * 1024 * 1024 // 75 MB
+// TODO: Long videos that exceed this threshold are extracted to audio-only to
+// avoid Lambda's 15-minute timeout. The proper fix is to offload transcoding
+// for these to a Fargate task so they get a proper compressed video rendition.
+//
+// Gated on source duration rather than file size — processing time tracks
+// video runtime far more closely than bytes on disk. A long, low-bitrate
+// recording has many more frames to decode/encode than a short, high-bitrate
+// file of the same size, so file size alone is a poor predictor of risk.
+const LARGE_VIDEO_DURATION_SECONDS = 30 * 60 // 30 minutes
 
 // Above this, even the audio-only fallback can't download from S3 to EFS within
 // Lambda's 15-minute timeout, so we reject without attempting the download at all.
@@ -118,8 +122,6 @@ async function run({ id, originalKey, mimeType }) {
     // 1. Download original
     await getS3File(bucket, originalKey, `${id}-orig.${ext}`)
 
-    const fileSizeBytes = fs.statSync(origLocalPath).size
-
     // Probe audio streams before transcoding. iPhones embed an undecodable Apple
     // spatial-audio (apac) track alongside the standard AAC; without an explicit
     // map, ffmpeg auto-selects the highest-channel-count stream and fails.
@@ -129,7 +131,8 @@ async function run({ id, originalKey, mimeType }) {
     // Confirm the file actually has a video stream before trusting the
     // mimeType/extension — some "video" uploads are audio-only.
     const hasVideo = video && (await hasVideoStream(origLocalPath))
-    const isLargeVideo = hasVideo && fileSizeBytes > LARGE_VIDEO_BYTES
+    const sourceDurationSeconds = hasVideo ? await getDuration(origLocalPath) : 0
+    const isLargeVideo = hasVideo && sourceDurationSeconds > LARGE_VIDEO_DURATION_SECONDS
 
     // Large videos are extracted to audio-only to stay within Lambda's timeout.
     // Normal videos transcode to mp4; audio and large-video fallbacks go to mp3.
@@ -143,17 +146,19 @@ async function run({ id, originalKey, mimeType }) {
 
     // 2. Transcode
     if (isLargeVideo) {
-      console.log(`Media ${id} is a large video (${(fileSizeBytes / 1024 / 1024).toFixed(0)} MB) — extracting audio only`)
+      console.log(`Media ${id} is a long video (${(sourceDurationSeconds / 60).toFixed(0)} min) — extracting audio only`)
       await runCommand(
         `ffmpeg -y -i ${escapeShellArg(origLocalPath)} ${aMap} -vn -c:a libmp3lame -b:a 192k ${escapeShellArg(renditionLocalPath)}`
       )
     } else if (hasVideo) {
       const aCodec = aMap ? '-c:a aac -b:a 128k' : ''
+      // superfast trades a bit of compression efficiency for a meaningful speed
+      // gain over veryfast, buying more headroom under Lambda's 15-minute timeout.
       // max_muxing_queue_size guards against "Too many packets buffered for
       // output stream" on long, low-bitrate videos where erratic input
       // timestamps make ffmpeg's default interleaving buffer overflow.
       await runCommand(
-        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -map 0:v:0 ${aMap} -dn -c:v libx264 -b:v 1500k -preset veryfast -vf scale=-2:720 ${aCodec} -max_muxing_queue_size 9999 ${escapeShellArg(renditionLocalPath)}`
+        `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -map 0:v:0 ${aMap} -dn -c:v libx264 -b:v 1500k -preset superfast -vf scale=-2:720 ${aCodec} -max_muxing_queue_size 9999 ${escapeShellArg(renditionLocalPath)}`
       )
     } else {
       await runCommand(

--- a/amplify/backend/function/processMedia/src/lib/media.js
+++ b/amplify/backend/function/processMedia/src/lib/media.js
@@ -52,6 +52,29 @@ async function selectAudioStream(filePath) {
   })
 }
 
+// Some mp4/m4v uploads are audio-only exports (voice memos, audio-only DaVinci
+// Resolve renders) despite the video-looking extension/mimeType. Confirm a video
+// stream actually exists before mapping it with -map 0:v:0, which otherwise fails
+// outright with "Stream map '0:v:0' matches no streams."
+async function hasVideoStream(filePath) {
+  return new Promise((resolve) => {
+    const { exec } = require('child_process')
+    exec(
+      `ffprobe -v error -select_streams v -show_entries stream=codec_name -of json ${escapeShellArg(filePath)}`,
+      { maxBuffer: 1024 * 64 },
+      (error, stdout) => {
+        if (error) { resolve(false); return }
+        try {
+          const { streams } = JSON.parse(stdout)
+          resolve(Boolean(streams && streams.length > 0))
+        } catch {
+          resolve(false)
+        }
+      }
+    )
+  })
+}
+
 async function getDuration(filePath) {
   return new Promise((resolve, reject) => {
     const { exec } = require('child_process')
@@ -96,17 +119,6 @@ async function run({ id, originalKey, mimeType }) {
     await getS3File(bucket, originalKey, `${id}-orig.${ext}`)
 
     const fileSizeBytes = fs.statSync(origLocalPath).size
-    const isLargeVideo = video && fileSizeBytes > LARGE_VIDEO_BYTES
-
-    // Large videos are extracted to audio-only to stay within Lambda's timeout.
-    // Normal videos transcode to mp4; audio and large-video fallbacks go to mp3.
-    const audioOnly = !video || isLargeVideo
-    const renditionExt = audioOnly ? 'mp3' : 'mp4'
-    const renditionMimeType = audioOnly ? 'audio/mpeg' : 'video/mp4'
-    const renditionLocalPath = `${efsPath}/${id}-rendition.${renditionExt}`
-    const renditionKey = `public/renditions/${id}.${renditionExt}`
-    const thumbLocalPath = audioOnly ? null : `${efsPath}/${id}-thumb.jpg`
-    const thumbnailKey = audioOnly ? null : `public/thumbnails/${id}.jpg`
 
     // Probe audio streams before transcoding. iPhones embed an undecodable Apple
     // spatial-audio (apac) track alongside the standard AAC; without an explicit
@@ -114,13 +126,28 @@ async function run({ id, originalKey, mimeType }) {
     const audioIdx = await selectAudioStream(origLocalPath)
     const aMap = audioIdx !== null ? `-map 0:a:${audioIdx}` : ''
 
+    // Confirm the file actually has a video stream before trusting the
+    // mimeType/extension — some "video" uploads are audio-only.
+    const hasVideo = video && (await hasVideoStream(origLocalPath))
+    const isLargeVideo = hasVideo && fileSizeBytes > LARGE_VIDEO_BYTES
+
+    // Large videos are extracted to audio-only to stay within Lambda's timeout.
+    // Normal videos transcode to mp4; audio and large-video fallbacks go to mp3.
+    const audioOnly = !hasVideo || isLargeVideo
+    const renditionExt = audioOnly ? 'mp3' : 'mp4'
+    const renditionMimeType = audioOnly ? 'audio/mpeg' : 'video/mp4'
+    const renditionLocalPath = `${efsPath}/${id}-rendition.${renditionExt}`
+    const renditionKey = `public/renditions/${id}.${renditionExt}`
+    const thumbLocalPath = audioOnly ? null : `${efsPath}/${id}-thumb.jpg`
+    const thumbnailKey = audioOnly ? null : `public/thumbnails/${id}.jpg`
+
     // 2. Transcode
     if (isLargeVideo) {
       console.log(`Media ${id} is a large video (${(fileSizeBytes / 1024 / 1024).toFixed(0)} MB) — extracting audio only`)
       await runCommand(
         `ffmpeg -y -i ${escapeShellArg(origLocalPath)} ${aMap} -vn -c:a libmp3lame -b:a 192k ${escapeShellArg(renditionLocalPath)}`
       )
-    } else if (video) {
+    } else if (hasVideo) {
       const aCodec = aMap ? '-c:a aac -b:a 128k' : ''
       await runCommand(
         `ffmpeg -y -i ${escapeShellArg(origLocalPath)} -map 0:v:0 ${aMap} -dn -c:v libx264 -b:v 1500k -preset veryfast -vf scale=-2:720 ${aCodec} ${escapeShellArg(renditionLocalPath)}`
@@ -160,7 +187,7 @@ async function run({ id, originalKey, mimeType }) {
     }
 
     // 9. Mark READY
-    const updates = { renditionKey, peaksKey, duration, audioOnly: isLargeVideo }
+    const updates = { renditionKey, peaksKey, duration, audioOnly: isLargeVideo || (video && !hasVideo) }
     if (thumbnailKey) updates.thumbnailKey = thumbnailKey
     await updateMediaStatus(id, 'READY', updates)
 

--- a/amplify/backend/function/processMedia/src/lib/media.js
+++ b/amplify/backend/function/processMedia/src/lib/media.js
@@ -19,7 +19,11 @@ const LARGE_VIDEO_DURATION_SECONDS = 30 * 60 // 30 minutes
 
 // Above this, even the audio-only fallback can't download from S3 to EFS within
 // Lambda's 15-minute timeout, so we reject without attempting the download at all.
-const MAX_DOWNLOAD_BYTES = 1 * 1024 * 1024 * 1024 // 1 GB
+// A production survey of uploaded originals found a handful of legitimate files
+// in the 1-5GB range (S3-to-Lambda transfer is fast enough that size alone isn't
+// the bottleneck there) alongside a few multi-GB raw camera dumps that are never
+// going to work regardless of cap — 5GB draws the line between them.
+const MAX_DOWNLOAD_BYTES = 5 * 1024 * 1024 * 1024 // 5 GB
 
 const VIDEO_MIME_PREFIXES = ['video/']
 const VIDEO_EXTENSIONS = ['mp4', 'm4v', 'mov', 'avi', 'mkv', 'webm', 'wmv']

--- a/amplify/backend/function/processMedia/src/lib/media.js
+++ b/amplify/backend/function/processMedia/src/lib/media.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const fs = require('fs')
-const { getS3File, putS3File, efsPath } = require('./s3')
+const { getS3FileSize, getS3File, putS3File, efsPath } = require('./s3')
 const { runCommand, generateWaveform, processPeaksData } = require('./audio')
 const { updateMediaStatus } = require('./dynamo')
 const { escapeShellArg } = require('../utils')
@@ -11,7 +11,11 @@ const bucket = process.env.STORAGE_TRANSCRIPTIONS_BUCKETNAME
 // to avoid Lambda's 15-minute timeout. The proper fix is to offload
 // transcoding for large files to a Fargate task so they get a proper
 // compressed video rendition.
-const LARGE_VIDEO_BYTES = 200 * 1024 * 1024 // 200 MB
+const LARGE_VIDEO_BYTES = 75 * 1024 * 1024 // 75 MB
+
+// Above this, even the audio-only fallback can't download from S3 to EFS within
+// Lambda's 15-minute timeout, so we reject without attempting the download at all.
+const MAX_DOWNLOAD_BYTES = 1 * 1024 * 1024 * 1024 // 1 GB
 
 const VIDEO_MIME_PREFIXES = ['video/']
 const VIDEO_EXTENSIONS = ['mp4', 'm4v', 'mov', 'avi', 'mkv', 'webm', 'wmv']
@@ -79,6 +83,15 @@ async function run({ id, originalKey, mimeType }) {
   const peaksKey = `public/peaks/${id}.json`
 
   try {
+    // 0. Reject outright if the original is too large to download within the
+    // Lambda timeout, before spending any time/EFS space on it.
+    const remoteSizeBytes = await getS3FileSize(bucket, originalKey)
+    if (remoteSizeBytes > MAX_DOWNLOAD_BYTES) {
+      throw new Error(
+        `Media ${id} originalKey is ${(remoteSizeBytes / 1024 / 1024 / 1024).toFixed(1)} GB, exceeding the ${(MAX_DOWNLOAD_BYTES / 1024 / 1024 / 1024).toFixed(1)} GB download cap`
+      )
+    }
+
     // 1. Download original
     await getS3File(bucket, originalKey, `${id}-orig.${ext}`)
 

--- a/amplify/backend/function/processMedia/src/lib/s3.js
+++ b/amplify/backend/function/processMedia/src/lib/s3.js
@@ -1,8 +1,13 @@
-const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3')
+const { S3Client, GetObjectCommand, PutObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3')
 const fs = require('fs')
 
 const s3Client = new S3Client({ region: process.env.REGION })
 const efsPath = '/mnt/temp'
+
+const getS3FileSize = async (bucket, key) => {
+  const { ContentLength } = await s3Client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }))
+  return ContentLength
+}
 
 const getS3File = async (bucket, key, filename) => {
   return new Promise(async (resolve, reject) => {
@@ -32,4 +37,4 @@ const putS3File = async (bucket, key, body, contentType = 'application/octet-str
   return s3Client.send(new PutObjectCommand(params))
 }
 
-module.exports = { getS3File, putS3File, efsPath }
+module.exports = { getS3FileSize, getS3File, putS3File, efsPath }

--- a/amplify/backend/function/processMedia/src/test/test-media.js
+++ b/amplify/backend/function/processMedia/src/test/test-media.js
@@ -88,9 +88,11 @@ describe('media.run', () => {
   it('branches into video path for video/mp4 mime type', async () => {
     await run({ id: 'xyz', originalKey: 'public/originals/xyz.mp4', mimeType: 'video/mp4' })
 
-    // ffmpeg video transcode command used
+    // ffmpeg video transcode command used, with a muxing queue guard against
+    // "Too many packets buffered" on erratic input timestamps
     const transcodeCall = mockRunCommand.mock.calls.find(c => c[0].includes('libx264'))
     expect(transcodeCall).toBeTruthy()
+    expect(transcodeCall[0]).toContain('-max_muxing_queue_size')
 
     // Thumbnail generated for video
     const thumbCall = mockRunCommand.mock.calls.find(c => c[0].includes('-frames:v'))

--- a/amplify/backend/function/processMedia/src/test/test-media.js
+++ b/amplify/backend/function/processMedia/src/test/test-media.js
@@ -35,6 +35,9 @@ jest.mock('child_process', () => ({
     if (typeof cmd === 'string' && cmd.includes('-select_streams a')) {
       // ffprobe audio selection: single decodable AAC stream by default
       callback(null, JSON.stringify({ streams: [{ codec_name: 'aac' }] }), '')
+    } else if (typeof cmd === 'string' && cmd.includes('-select_streams v')) {
+      // ffprobe video-stream check: has a video stream by default
+      callback(null, JSON.stringify({ streams: [{ codec_name: 'h264' }] }), '')
     } else {
       callback(null, '5.0', '') // ffprobe duration
     }
@@ -161,6 +164,39 @@ describe('media.run', () => {
     expect(mockGetS3File).not.toHaveBeenCalled()
     const errorCall = mockUpdateMediaStatus.mock.calls.find(c => c[1] === 'ERROR')
     expect(errorCall).toBeTruthy()
+  })
+
+  it('falls back to audio when a video-tagged file has no actual video stream', async () => {
+    // mp4 container that's actually an audio-only export (voice memo, audio-only
+    // DaVinci Resolve render, etc.) — audio probe first, then video probe finds nothing
+    const { exec } = require('child_process')
+    exec
+      .mockImplementationOnce((cmd, optsOrCb, cb) => {
+        const callback = typeof optsOrCb === 'function' ? optsOrCb : cb
+        callback(null, JSON.stringify({ streams: [{ codec_name: 'aac' }] }), '')
+      })
+      .mockImplementationOnce((cmd, optsOrCb, cb) => {
+        const callback = typeof optsOrCb === 'function' ? optsOrCb : cb
+        callback(null, JSON.stringify({ streams: [] }), '')
+      })
+
+    await run({ id: 'voiceclip', originalKey: 'public/originals/voiceclip.mp4', mimeType: 'video/mp4' })
+
+    const videoCall = mockRunCommand.mock.calls.find(c => c[0].includes('libx264'))
+    expect(videoCall).toBeUndefined()
+    const audioCall = mockRunCommand.mock.calls.find(c => c[0].includes('libmp3lame'))
+    expect(audioCall).toBeTruthy()
+    expect(audioCall[0]).not.toContain('-map 0:v:0')
+
+    // No thumbnail — there's no video frame to grab
+    const thumbCall = mockRunCommand.mock.calls.find(c => c[0].includes('-frames:v'))
+    expect(thumbCall).toBeUndefined()
+
+    const readyCall = mockUpdateMediaStatus.mock.calls.find(c => c[1] === 'READY')
+    expect(readyCall).toBeTruthy()
+    expect(readyCall[2].renditionKey).toBe('public/renditions/voiceclip.mp3')
+    expect(readyCall[2].thumbnailKey).toBeUndefined()
+    expect(readyCall[2].audioOnly).toBe(true)
   })
 
   it('skips undecodable apac track and maps the next decodable audio stream', async () => {

--- a/amplify/backend/function/processMedia/src/test/test-media.js
+++ b/amplify/backend/function/processMedia/src/test/test-media.js
@@ -24,7 +24,6 @@ jest.mock('fs', () => ({
   existsSync: jest.fn().mockReturnValue(false),
   readFileSync: jest.fn().mockReturnValue(Buffer.from('rendition-bytes')),
   readdirSync: jest.fn().mockReturnValue([]),
-  statSync: jest.fn().mockReturnValue({ size: 1024 * 1024 }), // 1 MB — below large-video threshold
   createWriteStream: jest.fn(),
   unlinkSync: jest.fn(),
 }))
@@ -88,10 +87,12 @@ describe('media.run', () => {
   it('branches into video path for video/mp4 mime type', async () => {
     await run({ id: 'xyz', originalKey: 'public/originals/xyz.mp4', mimeType: 'video/mp4' })
 
-    // ffmpeg video transcode command used, with a muxing queue guard against
-    // "Too many packets buffered" on erratic input timestamps
+    // ffmpeg video transcode command used, with the superfast preset and a
+    // muxing queue guard against "Too many packets buffered" on erratic input
+    // timestamps
     const transcodeCall = mockRunCommand.mock.calls.find(c => c[0].includes('libx264'))
     expect(transcodeCall).toBeTruthy()
+    expect(transcodeCall[0]).toContain('-preset superfast')
     expect(transcodeCall[0]).toContain('-max_muxing_queue_size')
 
     // Thumbnail generated for video
@@ -107,9 +108,21 @@ describe('media.run', () => {
     expect(readyCall[2].audioOnly).toBe(false)
   })
 
-  it('sets audioOnly true for a large video transcoded to audio', async () => {
-    const { statSync } = require('fs')
-    statSync.mockReturnValueOnce({ size: 100 * 1024 * 1024 }) // 100 MB — above the 75 MB threshold
+  it('sets audioOnly true for a video longer than the 30-minute threshold', async () => {
+    const { exec } = require('child_process')
+    exec
+      .mockImplementationOnce((cmd, optsOrCb, cb) => { // audio stream select
+        const callback = typeof optsOrCb === 'function' ? optsOrCb : cb
+        callback(null, JSON.stringify({ streams: [{ codec_name: 'aac' }] }), '')
+      })
+      .mockImplementationOnce((cmd, optsOrCb, cb) => { // video stream select
+        const callback = typeof optsOrCb === 'function' ? optsOrCb : cb
+        callback(null, JSON.stringify({ streams: [{ codec_name: 'h264' }] }), '')
+      })
+      .mockImplementationOnce((cmd, optsOrCb, cb) => { // source duration probe
+        const callback = typeof optsOrCb === 'function' ? optsOrCb : cb
+        callback(null, '2400.0', '') // 40 minutes — above the 30-minute threshold
+      })
 
     await run({ id: 'big', originalKey: 'public/originals/big.mp4', mimeType: 'video/mp4' })
 

--- a/amplify/backend/function/processMedia/src/test/test-media.js
+++ b/amplify/backend/function/processMedia/src/test/test-media.js
@@ -1,4 +1,5 @@
 const mockUpdateMediaStatus = jest.fn()
+const mockGetS3FileSize = jest.fn()
 const mockGetS3File = jest.fn()
 const mockPutS3File = jest.fn()
 const mockRunCommand = jest.fn()
@@ -6,7 +7,12 @@ const mockGenerateWaveform = jest.fn()
 const mockProcessPeaksData = jest.fn()
 
 jest.mock('../lib/dynamo', () => ({ updateMediaStatus: mockUpdateMediaStatus }))
-jest.mock('../lib/s3', () => ({ getS3File: mockGetS3File, putS3File: mockPutS3File, efsPath: '/mnt/temp' }))
+jest.mock('../lib/s3', () => ({
+  getS3FileSize: mockGetS3FileSize,
+  getS3File: mockGetS3File,
+  putS3File: mockPutS3File,
+  efsPath: '/mnt/temp',
+}))
 jest.mock('../lib/audio', () => ({
   runCommand: mockRunCommand,
   generateWaveform: mockGenerateWaveform,
@@ -45,6 +51,7 @@ describe('media.run', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUpdateMediaStatus.mockResolvedValue({})
+    mockGetS3FileSize.mockResolvedValue(1024 * 1024) // 1 MB — well under the download cap
     mockGetS3File.mockResolvedValue({})
     mockRunCommand.mockResolvedValue()
     mockGenerateWaveform.mockResolvedValue('/mnt/temp/abc-rendition.mp3.json')
@@ -97,7 +104,7 @@ describe('media.run', () => {
 
   it('sets audioOnly true for a large video transcoded to audio', async () => {
     const { statSync } = require('fs')
-    statSync.mockReturnValueOnce({ size: 201 * 1024 * 1024 }) // 201 MB — above threshold
+    statSync.mockReturnValueOnce({ size: 100 * 1024 * 1024 }) // 100 MB — above the 75 MB threshold
 
     await run({ id: 'big', originalKey: 'public/originals/big.mp4', mimeType: 'video/mp4' })
 
@@ -140,6 +147,18 @@ describe('media.run', () => {
 
     await expect(run({ id: 'abc', originalKey: 'public/originals/abc.mp3', mimeType: 'audio/mpeg' })).rejects.toThrow('S3 error')
 
+    const errorCall = mockUpdateMediaStatus.mock.calls.find(c => c[1] === 'ERROR')
+    expect(errorCall).toBeTruthy()
+  })
+
+  it('rejects without downloading when the S3 object exceeds the 1 GB download cap', async () => {
+    mockGetS3FileSize.mockResolvedValueOnce(2 * 1024 * 1024 * 1024) // 2 GB
+
+    await expect(
+      run({ id: 'huge', originalKey: 'public/originals/huge.mp4', mimeType: 'video/mp4' })
+    ).rejects.toThrow(/exceeding the 1\.0 GB download cap/)
+
+    expect(mockGetS3File).not.toHaveBeenCalled()
     const errorCall = mockUpdateMediaStatus.mock.calls.find(c => c[1] === 'ERROR')
     expect(errorCall).toBeTruthy()
   })

--- a/amplify/backend/function/processMedia/src/test/test-media.js
+++ b/amplify/backend/function/processMedia/src/test/test-media.js
@@ -169,12 +169,12 @@ describe('media.run', () => {
     expect(errorCall).toBeTruthy()
   })
 
-  it('rejects without downloading when the S3 object exceeds the 1 GB download cap', async () => {
-    mockGetS3FileSize.mockResolvedValueOnce(2 * 1024 * 1024 * 1024) // 2 GB
+  it('rejects without downloading when the S3 object exceeds the 5 GB download cap', async () => {
+    mockGetS3FileSize.mockResolvedValueOnce(10 * 1024 * 1024 * 1024) // 10 GB
 
     await expect(
       run({ id: 'huge', originalKey: 'public/originals/huge.mp4', mimeType: 'video/mp4' })
-    ).rejects.toThrow(/exceeding the 1\.0 GB download cap/)
+    ).rejects.toThrow(/exceeding the 5\.0 GB download cap/)
 
     expect(mockGetS3File).not.toHaveBeenCalled()
     const errorCall = mockUpdateMediaStatus.mock.calls.find(c => c[1] === 'ERROR')

--- a/scripts/create-media-for-transcriptions.js
+++ b/scripts/create-media-for-transcriptions.js
@@ -18,7 +18,8 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, ScanCommand, GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { fromIni } from '@aws-sdk/credential-providers';
 import { randomUUID } from 'crypto';
-import { writeFileSync } from 'fs';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
 
 const CLI_ARGS = process.argv.slice(2);
 
@@ -425,6 +426,9 @@ async function main() {
   let errorCount = 0;
   const failures = [];
 
+  mkdirSync('logs', { recursive: true });
+  const logPath = join('logs', `migration-errors-${Date.now()}.json`);
+
   for (const transcription of legacy) {
     const originalKey = extractKeyFromUrl(transcription.source);
     const originalName = extractOriginalName(transcription.source);
@@ -442,6 +446,9 @@ async function main() {
       console.error(`  ❌ Failed: ${err.message}`);
       errorCount++;
       failures.push({ id: transcription.id, title: transcription.title, originalName, error: err.message });
+      // Written immediately, not just at the end, so a cancelled or crashed
+      // run doesn't lose track of failures already encountered.
+      writeFileSync(logPath, JSON.stringify(failures, null, 2));
     }
   }
 
@@ -450,11 +457,6 @@ async function main() {
 
   await backfillMediaAcls(all);
   await backfillAudioOnly(allMediaAfter);
-
-  const logPath = `migration-errors-${Date.now()}.json`;
-  if (failures.length > 0) {
-    writeFileSync(logPath, JSON.stringify(failures, null, 2));
-  }
 
   console.log('\n' + '='.repeat(80));
   console.log('Migration complete!');

--- a/scripts/create-media-for-transcriptions.js
+++ b/scripts/create-media-for-transcriptions.js
@@ -82,17 +82,28 @@ const docClient = DynamoDBDocumentClient.from(client);
  * Extract the S3 key from a legacy source URL.
  * e.g. "https://bucket.s3.amazonaws.com/public/1753823638851-filename.mp3"
  *   -> "public/1753823638851-filename.mp3"
+ *
+ * These URLs were built by concatenating the raw uploaded filename onto the
+ * bucket URL without percent-encoding reserved characters, so filenames
+ * containing a literal '#' or '?' (e.g. "Story #1.m4a") are common. Parsing
+ * with `new URL()` treats those as the start of a fragment/query string and
+ * silently truncates the key there, so the key is taken verbatim from after
+ * the host instead of relying on `.pathname`.
  */
 function extractKeyFromUrl(sourceUrl) {
+  const hostMatch = sourceUrl.match(/^https?:\/\/[^/]+\//);
+  const rawKey = hostMatch ? sourceUrl.slice(hostMatch[0].length) : sourceUrl.split('amazonaws.com/')[1];
+
+  if (!rawKey) return sourceUrl;
+
   try {
-    const url = new URL(sourceUrl);
-    // pathname is "/public/1753823638851-filename.mp3" — decode so S3 gets
-    // the literal key (spaces etc.) rather than the %20-encoded form
-    return decodeURIComponent(url.pathname.slice(1));
+    // Decode any legitimately percent-encoded characters (e.g. %20 for a space)
+    // so S3 gets the literal key rather than the encoded form.
+    return decodeURIComponent(rawKey);
   } catch {
-    // Fallback: split on the domain part
-    const parts = sourceUrl.split('amazonaws.com/');
-    return parts.length > 1 ? decodeURIComponent(parts[1]) : sourceUrl;
+    // A literal '%' not part of a valid escape sequence (e.g. "100% Done.mp4") —
+    // leave it as-is rather than losing the key entirely.
+    return rawKey;
   }
 }
 
@@ -104,9 +115,8 @@ function extractOriginalName(sourceUrl) {
   try {
     const key = extractKeyFromUrl(sourceUrl);
     const filename = key.split('/').pop();
-    const decoded = decodeURIComponent(filename);
-    const match = decoded.match(/^\d+-(.+)$/);
-    return match ? match[1] : decoded;
+    const match = filename.match(/^\d+-(.+)$/);
+    return match ? match[1] : filename;
   } catch {
     return 'unknown';
   }

--- a/src/components/forms/TranscriptionSettingsPage.tsx
+++ b/src/components/forms/TranscriptionSettingsPage.tsx
@@ -484,7 +484,7 @@ export const TranscriptionSettingsPage = ({
                     <div className="flex items-start gap-2 p-3 bg-yellow-50 border border-yellow-300 rounded-lg text-sm text-yellow-800">
                       <AlertTriangle className="flex-shrink-0 mt-0.5" size={16} />
                       <p>
-                        Your original video file was too large to transcode for web playback, so it was converted to audio only. The video track is not available. If you need the video, please re-upload a smaller or compressed version of the file.
+                        Only audio is available for this file. Either the source video is longer than we can process for web playback, or the uploaded file didn't actually contain a video track. If you need the video, please verify the original file or re-upload a shorter or compressed version.
                       </p>
                     </div>
                   )}


### PR DESCRIPTION
resolve #300

Fixes for the failures found while migrating production media:

- Reject S3 objects over 5GB before downloading, instead of timing out mid-download (a survey of production originals showed size alone isn't the bottleneck below ~5GB given S3-to-Lambda transfer speed; only a few genuine 11-151GB raw camera dumps need excluding)
- Gate the audio-only fallback on video duration (30 min) instead of file size, and bump the transcode preset to `superfast` for extra headroom — file size barely correlated with transcode time in the actual data, while duration tracked it closely (7 failures — 84–199MB files timing out on full transcode despite being under the old 200MB cutoff)
- Probe for an actual video stream before transcoding, instead of trusting mimeType/extension (15 failures — mp4/m4v uploads that were actually audio-only exports)
- Fix source URL key extraction truncating on unencoded `#`/`?` in filenames (2 failures — files weren't missing, just mis-parsed)
- Add `-max_muxing_queue_size` to guard against ffmpeg buffer overflow on long, low-bitrate videos (2 failures)
- Write the migration script's error log to `logs/` incrementally as failures happen, instead of the project root at the end of the run
- Update the audio-only warning copy in the transcription settings page to match the real fallback reasons (duration/no video track, not file size)

One failure (a non-media `.docx` upload) isn't fixable in code.

### Testing
Full unit test suite (2142 tests), lint, and build all pass. E2E tests passed. New regression tests cover the download cap, the duration-based threshold, the missing-video-stream fallback, and the muxing-queue flag.