### PR TITLE
Add e2e coverage for editor text, list management, issues, and database

### DIFF
--- a/src/components/issues/IssueDetailsDialog.tsx
+++ b/src/components/issues/IssueDetailsDialog.tsx
@@ -195,6 +195,7 @@ export const IssueDetailsDialog = ({
           <div className="flex items-center gap-1">
             {canResolve && (
               <button
+                data-testid="issue-resolve-toggle"
                 onClick={handleToggleResolved}
                 title={issue.resolved ? 'Reopen issue' : 'Resolve issue'}
                 className={`p-2 rounded-md transition-colors ${
@@ -208,6 +209,7 @@ export const IssueDetailsDialog = ({
             )}
             {canDelete && (
               <button
+                data-testid="issue-delete-button"
                 onClick={handleDeleteIssue}
                 title="Delete issue"
                 className="p-2 rounded-md text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors"
@@ -293,6 +295,7 @@ export const IssueDetailsDialog = ({
                       {/* Delete button */}
                       {canDeleteThisComment && (
                         <button
+                          data-testid="comment-delete-button"
                           onClick={() => handleDeleteComment(comment.id)}
                           className="p-1 rounded text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors flex-shrink-0"
                           title="Delete comment"

--- a/src/components/list/TranscriptionsList.tsx
+++ b/src/components/list/TranscriptionsList.tsx
@@ -383,6 +383,7 @@ export const TranscriptionsList = () => {
             {/* Search */}
             <div className="relative">
               <input
+                data-testid="transcription-search-input"
                 type="text"
                 placeholder="Search by title..."
                 value={search}
@@ -397,6 +398,7 @@ export const TranscriptionsList = () => {
             {/* Sort Dropdown */}
             <div className="relative">
               <select
+                data-testid="transcription-sort-select"
                 value={`${sortBy}-${sortDesc ? 'desc' : 'asc'}`}
                 onChange={(e) => {
                   const [key, direction] = e.target.value.split('-');
@@ -695,6 +697,7 @@ export const TranscriptionsList = () => {
                         })()}
                         {transcription.isMine(user?.userId) && (
                           <button
+                            data-testid="transcription-delete-button"
                             onClick={() => handleDeleteClick(transcription)}
                             className="p-1 text-gray-400 hover:text-red-500 rounded transition-colors"
                             title="Delete transcription"

--- a/src/components/list/TranscriptionsList.tsx
+++ b/src/components/list/TranscriptionsList.tsx
@@ -481,6 +481,8 @@ export const TranscriptionsList = () => {
           {displayedTranscriptions.map((transcription) => (
             <div
               key={transcription.id}
+              data-testid="transcription-list-item"
+              data-transcription-id={transcription.id}
               className="relative bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
             >
               {/* Bottom progress border */}

--- a/src/components/regions/RegionEditor.tsx
+++ b/src/components/regions/RegionEditor.tsx
@@ -173,11 +173,12 @@ export const RegionEditor = memo(({
           {/* Tab Toggle Button Group */}
           <div className="flex border border-gray-300 rounded overflow-hidden" style={{ fontSize: '12px' }}>
             <button
+              data-testid="region-tab-orig"
               className={`px-1.5 py-0.5 font-medium uppercase transition-all duration-200 ${
                 activeTab === 'main'
                   ? 'bg-gray-300 text-gray-800 shadow-inner border-t border-gray-400'
-                  : canEdit 
-                    ? 'bg-white text-gray-600 hover:bg-gray-100 cursor-pointer' 
+                  : canEdit
+                    ? 'bg-white text-gray-600 hover:bg-gray-100 cursor-pointer'
                     : 'bg-gray-50 text-gray-400 cursor-not-allowed'
               }`}
               onClick={canEdit ? () => setActiveTab('main') : undefined}
@@ -188,11 +189,12 @@ export const RegionEditor = memo(({
               <span className="hidden lg:inline">ORIG</span>
             </button>
             <button
+              data-testid="region-tab-tran"
               className={`px-1.5 py-0.5 font-medium uppercase transition-all duration-200 border-l border-gray-300 ${
                 activeTab === 'translation'
                   ? 'bg-gray-300 text-gray-800 shadow-inner border-t border-gray-400'
-                  : canEdit 
-                    ? 'bg-white text-gray-600 hover:bg-gray-100 cursor-pointer' 
+                  : canEdit
+                    ? 'bg-white text-gray-600 hover:bg-gray-100 cursor-pointer'
                     : 'bg-gray-50 text-gray-400 cursor-not-allowed'
               }`}
               onClick={canEdit ? () => setActiveTab('translation') : undefined}
@@ -298,8 +300,9 @@ export const RegionEditor = memo(({
 
         {activeTab === 'translation' && (
           <div className="h-full" style={{ backgroundColor: '#f5f5f5' }}>
-            <div 
+            <div
               ref={translationEditorRef}
+              data-testid="region-editor-translation"
               className="h-full"
               style={{ backgroundColor: '#f5f5f5' }}
             />

--- a/src/pages/DatabaseHomePage.tsx
+++ b/src/pages/DatabaseHomePage.tsx
@@ -255,6 +255,7 @@ export const DatabaseHomePage = () => {
               </label>
               <select
                 id="header-language-selector"
+                data-testid="database-language-select"
                 value={selectedLang}
                 onChange={(e) => handleLanguageChange(e.target.value)}
                 disabled={loading}
@@ -295,6 +296,7 @@ export const DatabaseHomePage = () => {
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
                 <input
                   ref={searchInputRef}
+                  data-testid="database-search-input"
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
@@ -315,7 +317,7 @@ export const DatabaseHomePage = () => {
 
             {/* Search Results */}
             {searchResults.length > 0 && (
-              <div className="mt-6 bg-white rounded-lg border border-gray-200 overflow-hidden">
+              <div data-testid="database-search-results" className="mt-6 bg-white rounded-lg border border-gray-200 overflow-hidden">
                 <div className="px-4 py-3 border-b border-gray-200 bg-gray-50">
                   <h3 className="font-medium text-gray-900">
                     {searchResults.length} {searchResults.length === 1 ? 'result' : 'results'}

--- a/src/pages/DatabaseLemmaPage.tsx
+++ b/src/pages/DatabaseLemmaPage.tsx
@@ -163,7 +163,7 @@ export const DatabaseLemmaPage = () => {
             >
               <ArrowLeft size={20} />
             </button>
-            <h1 className="text-2xl font-semibold text-gray-900 ml-3">
+            <h1 data-testid="lemma-page-header" className="text-2xl font-semibold text-gray-900 ml-3">
               {decodedLemma}
             </h1>
           </div>

--- a/tests/README.md
+++ b/tests/README.md
@@ -118,6 +118,10 @@ TEST_PARALLEL_INDEX=1 npm run test:e2e
 
 Available account names: `owner`, `viewer`, `editor`
 
+## Coverage
+
+See [`tests/e2e/COVERAGE.md`](./e2e/COVERAGE.md) for a matrix of core flows vs. their test status. Keep it updated when adding or removing specs.
+
 ## Important Notes
 
 - The `playwright/.auth/` directory and `.env` file are gitignored for security

--- a/tests/e2e/COVERAGE.md
+++ b/tests/e2e/COVERAGE.md
@@ -1,0 +1,118 @@
+# E2E Coverage Matrix
+
+This file tracks which core user flows are covered by end-to-end tests. Update it whenever a spec is added, extended, or removed. Its purpose is to make coverage gaps visible so regressions don't go undetected — issue #305 (discoverable transcriptions broken for weeks) motivated its creation.
+
+## Status key
+
+- **covered** — at least one test exercises this flow end-to-end against the real API
+- **partial** — tested in one direction but not the full lifecycle (e.g. create but not delete)
+- **untested** — no e2e test exists for this flow
+
+---
+
+## Authentication
+
+| Flow | Status | Spec |
+|---|---|---|
+| Authenticated user can reach protected routes | covered | `transcription.spec.ts` |
+| Unauthenticated redirect to login | untested | — |
+| Sign-out / sign-in round-trip | untested | — |
+
+## Transcription list
+
+| Flow | Status | Spec |
+|---|---|---|
+| List loads for owner (My Transcriptions tab) | covered | `transcription.spec.ts` |
+| Shared with Me tab | covered | `reload.spec.ts`, `invites.spec.ts` |
+| Title search/filter | covered | `list-management.spec.ts` |
+| Sort control | covered | `list-management.spec.ts` |
+| Delete via list trash button | covered | `list-management.spec.ts` |
+| Mobile list layout | untested | — |
+| Privacy badge (Private / Discoverable) | untested | — |
+
+## Upload & media processing
+
+| Flow | Status | Spec |
+|---|---|---|
+| Upload MP3 and wait for READY status | covered (via helper) | `transcription.spec.ts`, all specs using `createTestTranscription` |
+| Media processing overlay visible during processing | untested | — |
+| Media error overlay | untested | — |
+
+## Editor — regions
+
+| Flow | Status | Spec |
+|---|---|---|
+| Create region by waveform drag | covered | `transcription.spec.ts` |
+| Delete region | covered | `transcription.spec.ts` |
+| Region count visible in header | covered | multiple specs |
+| Merge two adjacent regions | covered | `editor-text.spec.ts` |
+| Region bounds resize/drag | untested | — |
+
+## Editor — text editing
+
+| Flow | Status | Spec |
+|---|---|---|
+| ORIG text typed and persists after reload | covered | `editor-text.spec.ts` |
+| TRAN (translation) text typed and persists after reload | covered | `editor-text.spec.ts` |
+| Spellcheck highlight on typed word | covered | `transcription.spec.ts` |
+| Spellcheck correction (click suggestion) | untested | — |
+| ORIG/TRAN tab toggle | covered (via TRAN test) | `editor-text.spec.ts` |
+
+## Editor — issues & comments
+
+| Flow | Status | Spec |
+|---|---|---|
+| Owner creates issue from text selection | covered | `issues.spec.ts` |
+| Issue visible in IssuesPanel after reload | covered | `issues.spec.ts` |
+| Issue visible to invited editor | covered | `issues.spec.ts` |
+| Resolve issue; persists after reload | covered | `issues.spec.ts` |
+| Delete issue; persists after reload | covered | `issues.spec.ts` |
+| Post comment; visible to other user | covered | `issues.spec.ts` |
+| Delete comment | covered | `issues.spec.ts` |
+| Issue type change | untested | — |
+
+## Collaboration / invites
+
+| Flow | Status | Spec |
+|---|---|---|
+| Owner sends invite | covered | `invites.spec.ts` |
+| Invitee accepts invite | covered | `invites.spec.ts` |
+| Accepted transcription appears in Shared with Me | covered | `invites.spec.ts`, `reload.spec.ts` |
+| Invite permission level select visible | covered | `invite-management.spec.ts` |
+| Change pending invite permission | covered | `invite-management.spec.ts` |
+| Delete pending invite | covered | `invite-management.spec.ts` |
+| Editor can create/delete regions on shared transcription | covered | `sharing.spec.ts` |
+| Viewer cannot create regions | covered | `sharing.spec.ts` |
+| Revoke / resend invite | untested | — |
+
+## Discoverable (public) transcriptions
+
+| Flow | Status | Spec |
+|---|---|---|
+| Non-owner can open a discoverable transcription | covered | `discoverable.spec.ts` |
+| Non-owner denied access to private transcription | covered | `discoverable.spec.ts` |
+
+## Access control (GraphQL / AppSync layer)
+
+| Flow | Status | Spec |
+|---|---|---|
+| Uninvited user cannot read/mutate regions | covered | `security-acl.spec.ts` |
+| Uninvited user cannot list issues/comments | covered | `security-acl.spec.ts` |
+
+## Language Database
+
+| Flow | Status | Spec |
+|---|---|---|
+| /database page loads; language selector visible | covered | `database.spec.ts` |
+| Search input visible and accepts text after language selected | covered | `database.spec.ts` |
+| Search returns results or no-results message | covered | `database.spec.ts` |
+| Lemma detail page loads and shows lemma header | covered | `database.spec.ts` |
+| Attestation click navigates to transcription | untested | — |
+| Stats page | untested | — (page is not yet implemented) |
+
+## Out of scope (tracked here, not planned near-term)
+
+- Conflict-resolution dialog (`ConflictResolutionDialog.tsx`) — optimistic-versioning edge case, hard to reproduce in e2e
+- Concurrent-edit presence indicators — same; needs two simultaneous editing sessions
+- Mobile list card layout — requires viewport override; low priority vs. desktop
+- Amplify sign-out/sign-in UI — Amplify-internal selectors, fragile; covered by auth-state reset in global setup

--- a/tests/e2e/database.spec.ts
+++ b/tests/e2e/database.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Language Database smoke coverage
+ *
+ * - /database page loads and the language selector is visible
+ * - After selecting a language the search input is visible and accepts text
+ * - After typing a query the search either shows results or a no-results message
+ * - /database/lemma/:lemma page loads and shows the lemma in the header
+ *
+ * These are read-only, owner-pinned tests that exercise the database feature
+ * end-to-end against the real AppSync/Lambda backend. Content availability
+ * depends on indexed data in staging; assertions are scoped to UI mechanics
+ * rather than specific lemma content to avoid flakiness.
+ *
+ * The DatabaseTermsDialog is dismissed by pre-seeding localStorage so it
+ * does not block interactions.
+ */
+import { testWithAccount, expect } from '../../playwright/fixtures';
+
+const DATABASE_TERMS_ACCEPTED_KEY = 'database-terms-accepted';
+// Plains Cree Y-dialect — most likely to have indexed content on staging
+const TEST_LANG = 'crk';
+// A word known to exist in Plains Cree; wildcard so it matches even partial data
+const TEST_QUERY = 'êkosi';
+
+testWithAccount('owner').describe('Language Database', () => {
+  testWithAccount('owner').beforeEach(async ({ page }) => {
+    // Accept the terms dialog via localStorage so it never blocks the test
+    await page.addInitScript((key) => {
+      localStorage.setItem(key, 'true');
+    }, DATABASE_TERMS_ACCEPTED_KEY);
+  });
+
+  testWithAccount('owner')('database page loads with language selector', async ({ page }) => {
+    await page.goto('/database');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/.*\/database.*/);
+
+    const languageSelect = page.locator('[data-testid="database-language-select"]').first();
+    await expect(languageSelect).toBeVisible({ timeout: 10000 });
+    console.log('✅ /database page loaded; language selector visible');
+  });
+
+  testWithAccount('owner')('search input is visible after selecting a language and accepts text', async ({ page }) => {
+    await page.goto('/database');
+    await page.waitForLoadState('networkidle');
+
+    // Select language
+    const languageSelect = page.locator('[data-testid="database-language-select"]').first();
+    await expect(languageSelect).toBeVisible({ timeout: 10000 });
+    await languageSelect.selectOption(TEST_LANG);
+    await page.waitForTimeout(1000);
+
+    // Search input should now be visible (it's gated on language selection)
+    const searchInput = page.locator('[data-testid="database-search-input"]').first();
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+
+    // Type a query and verify the input value updates
+    await searchInput.fill(TEST_QUERY);
+    await expect(searchInput).toHaveValue(TEST_QUERY);
+    console.log('✅ Search input accepts text after language selection');
+  });
+
+  testWithAccount('owner')('typing a query shows results or a no-results message', async ({ page }) => {
+    await page.goto('/database');
+    await page.waitForLoadState('networkidle');
+
+    const languageSelect = page.locator('[data-testid="database-language-select"]').first();
+    await expect(languageSelect).toBeVisible({ timeout: 10000 });
+    await languageSelect.selectOption(TEST_LANG);
+    await page.waitForTimeout(1000);
+
+    const searchInput = page.locator('[data-testid="database-search-input"]').first();
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+    await searchInput.fill(TEST_QUERY);
+
+    // Wait for the 600 ms debounce + API response
+    await page.waitForTimeout(4000);
+
+    // Either results or the no-results message should be visible
+    const hasResults = await page.locator('[data-testid="database-search-results"]').isVisible().catch(() => false);
+    const hasNoResults = await page.locator(`text=No results found for "${TEST_QUERY}"`).isVisible().catch(() => false);
+
+    expect(hasResults || hasNoResults).toBeTruthy();
+    console.log(`✅ Search produced ${hasResults ? 'results' : 'no-results message'} for "${TEST_QUERY}"`);
+  });
+
+  testWithAccount('owner')('lemma page loads and shows the lemma in the header', async ({ page }) => {
+    await page.goto(`/database/lemma/${encodeURIComponent(TEST_QUERY)}`);
+    await page.waitForLoadState('networkidle');
+
+    const header = page.locator('[data-testid="lemma-page-header"]').first();
+    await expect(header).toBeVisible({ timeout: 10000 });
+    await expect(header).toContainText(TEST_QUERY);
+    console.log(`✅ /database/lemma page loaded and shows "${TEST_QUERY}" in header`);
+  });
+});

--- a/tests/e2e/database.spec.ts
+++ b/tests/e2e/database.spec.ts
@@ -73,12 +73,13 @@ testWithAccount('owner').describe('Language Database', () => {
     await expect(searchInput).toBeVisible({ timeout: 10000 });
     await searchInput.fill(TEST_QUERY);
 
-    // Wait for the 600 ms debounce + API response
-    await page.waitForTimeout(4000);
+    // Wait for the 600 ms debounce + API response (Lambda cold start can add 2-4 s)
+    await page.waitForTimeout(10000);
 
     // Either results or the no-results message should be visible
     const hasResults = await page.locator('[data-testid="database-search-results"]').isVisible().catch(() => false);
-    const hasNoResults = await page.locator(`text=No results found for "${TEST_QUERY}"`).isVisible().catch(() => false);
+    // Use a prefix match to avoid Unicode encoding issues with the full query string
+    const hasNoResults = await page.locator('text=No results found').isVisible().catch(() => false);
 
     expect(hasResults || hasNoResults).toBeTruthy();
     console.log(`✅ Search produced ${hasResults ? 'results' : 'no-results message'} for "${TEST_QUERY}"`);

--- a/tests/e2e/editor-text.spec.ts
+++ b/tests/e2e/editor-text.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * Editor text & region coverage
+ *
+ * - ORIG text typed into a region persists after a hard reload
+ * - TRAN (translation) text persists after a hard reload
+ * - Region merge reduces the region count by 1
+ *
+ * These are the most central editor flows and were previously untested.
+ * All tests are owner-pinned; the transcription is created/deleted per test.
+ */
+import { testWithAccount, expect } from '../../playwright/fixtures';
+import { createTestTranscription, deleteTestTranscription, dragRegion, waitForAudioReady } from './helpers';
+
+testWithAccount('owner').describe('Editor text persistence', () => {
+  let transcriptionId: string;
+  let title: string;
+
+  testWithAccount('owner').beforeEach(async ({ page }) => {
+    const result = await createTestTranscription(page);
+    transcriptionId = result.transcriptionId;
+    title = result.title;
+  });
+
+  testWithAccount('owner').afterEach(async ({ page }) => {
+    await deleteTestTranscription(page, transcriptionId, title);
+    transcriptionId = '';
+    title = '';
+  });
+
+  testWithAccount('owner')('ORIG text persists after hard reload', async ({ page }) => {
+    await expect(page).toHaveURL(/.*transcribe-edit\/.*/);
+
+    // Create a region
+    await dragRegion(page);
+    await expect(page.locator('text=Regions (1)').first()).toBeVisible({ timeout: 15000 });
+
+    // Wait for audio decode, then select the region
+    await waitForAudioReady(page);
+    const regionItem = page.locator('[data-testid*="regionitem"]').first();
+    await expect(regionItem).toBeVisible();
+    await regionItem.click();
+    await page.waitForTimeout(1000);
+
+    // Type text in the ORIG Quill editor
+    const origEditor = page.locator('[data-testid="region-editor-main"] .ql-editor').first();
+    await expect(origEditor).toBeVisible({ timeout: 5000 });
+    await origEditor.click();
+    const testText = `test orig ${Date.now()}`;
+    await page.keyboard.type(testText);
+
+    // Wait for the debounced save (2500 ms debounce + API latency)
+    await page.waitForTimeout(6000);
+
+    // Hard reload
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-testid="waveform-container"]').first()).toBeVisible({ timeout: 30000 });
+
+    // Re-select the region and verify text is present
+    const reloadedRegion = page.locator('[data-testid*="regionitem"]').first();
+    await expect(reloadedRegion).toBeVisible({ timeout: 15000 });
+    await reloadedRegion.click();
+    await page.waitForTimeout(1000);
+
+    const reloadedEditor = page.locator('[data-testid="region-editor-main"] .ql-editor').first();
+    await expect(reloadedEditor).toBeVisible({ timeout: 5000 });
+    await expect(reloadedEditor).toContainText(testText, { timeout: 5000 });
+    console.log('✅ ORIG text persisted after hard reload');
+  });
+
+  testWithAccount('owner')('TRAN text persists after hard reload', async ({ page }) => {
+    await expect(page).toHaveURL(/.*transcribe-edit\/.*/);
+
+    // Create a region
+    await dragRegion(page);
+    await expect(page.locator('text=Regions (1)').first()).toBeVisible({ timeout: 15000 });
+
+    // Wait for audio decode, then select the region
+    await waitForAudioReady(page);
+    const regionItem = page.locator('[data-testid*="regionitem"]').first();
+    await expect(regionItem).toBeVisible();
+    await regionItem.click();
+    await page.waitForTimeout(1000);
+
+    // Switch to TRAN tab and type translation text
+    const tranTab = page.locator('[data-testid="region-tab-tran"]').first();
+    await expect(tranTab).toBeVisible({ timeout: 5000 });
+    await tranTab.click();
+    await page.waitForTimeout(500);
+
+    const tranEditor = page.locator('[data-testid="region-editor-translation"] .ql-editor').first();
+    await expect(tranEditor).toBeVisible({ timeout: 5000 });
+    await tranEditor.click();
+    const tranText = `test tran ${Date.now()}`;
+    await page.keyboard.type(tranText);
+
+    // Wait for the debounced save
+    await page.waitForTimeout(6000);
+
+    // Hard reload
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-testid="waveform-container"]').first()).toBeVisible({ timeout: 30000 });
+
+    // Re-select region, switch to TRAN, verify text
+    const reloadedRegion = page.locator('[data-testid*="regionitem"]').first();
+    await expect(reloadedRegion).toBeVisible({ timeout: 15000 });
+    await reloadedRegion.click();
+    await page.waitForTimeout(1000);
+
+    const reloadedTranTab = page.locator('[data-testid="region-tab-tran"]').first();
+    await expect(reloadedTranTab).toBeVisible({ timeout: 5000 });
+    await reloadedTranTab.click();
+    await page.waitForTimeout(500);
+
+    const reloadedTranEditor = page.locator('[data-testid="region-editor-translation"] .ql-editor').first();
+    await expect(reloadedTranEditor).toBeVisible({ timeout: 5000 });
+    await expect(reloadedTranEditor).toContainText(tranText, { timeout: 5000 });
+    console.log('✅ TRAN text persisted after hard reload');
+  });
+});
+
+testWithAccount('owner').describe('Region merge', () => {
+  let transcriptionId: string;
+  let title: string;
+
+  testWithAccount('owner').beforeEach(async ({ page }) => {
+    const result = await createTestTranscription(page);
+    transcriptionId = result.transcriptionId;
+    title = result.title;
+  });
+
+  testWithAccount('owner').afterEach(async ({ page }) => {
+    await deleteTestTranscription(page, transcriptionId, title);
+    transcriptionId = '';
+    title = '';
+  });
+
+  testWithAccount('owner')('merging two adjacent regions reduces count to 1', async ({ page }) => {
+    await expect(page).toHaveURL(/.*transcribe-edit\/.*/);
+
+    const waveformContainer = page.locator('[data-testid="waveform-container"]');
+    await expect(waveformContainer).toBeVisible();
+    const box = await waveformContainer.boundingBox();
+    if (!box) throw new Error('Could not get waveform bounding box');
+
+    // Drag first region (x+50 to x+150)
+    await page.mouse.move(box.x + 50, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 150, box.y + box.height / 2);
+    await page.mouse.up();
+    await page.waitForTimeout(2000);
+
+    // Drag second region (x+200 to x+300)
+    await page.mouse.move(box.x + 200, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 300, box.y + box.height / 2);
+    await page.mouse.up();
+    await page.waitForTimeout(2000);
+
+    await expect(page.locator('text=Regions (2)').first()).toBeVisible({ timeout: 15000 });
+    console.log('✅ Two regions created');
+
+    // Wait for audio decode, click first region to open the editor
+    await waitForAudioReady(page);
+    const firstRegion = page.locator('[data-testid*="regionitem"]').first();
+    await expect(firstRegion).toBeVisible();
+    await firstRegion.click();
+    await page.waitForTimeout(1000);
+
+    // Click merge-next
+    const mergeButton = page.locator('[data-testid="merge-next-button"]').first();
+    await expect(mergeButton).toBeEnabled({ timeout: 5000 });
+    await mergeButton.click();
+    await page.waitForTimeout(2000);
+
+    await expect(page.locator('text=Regions (1)').first()).toBeVisible({ timeout: 10000 });
+    console.log('✅ Merge reduced region count to 1');
+  });
+});

--- a/tests/e2e/editor-text.spec.ts
+++ b/tests/e2e/editor-text.spec.ts
@@ -161,20 +161,22 @@ testWithAccount('owner').describe('Region merge', () => {
     await expect(page.locator('text=Regions (2)').first()).toBeVisible({ timeout: 15000 });
     console.log('✅ Two regions created');
 
-    // Wait for audio decode, click first region to open the editor
+    // Wait for both create-region API calls to settle in the database before merging
     await waitForAudioReady(page);
+    await page.waitForTimeout(5000);
     const firstRegion = page.locator('[data-testid*="regionitem"]').first();
     await expect(firstRegion).toBeVisible();
     await firstRegion.click();
     await page.waitForTimeout(1000);
 
-    // Click merge-next
+    // Click merge-next — accept the confirm dialog that fires before the merge
+    page.once('dialog', async (dialog) => dialog.accept());
     const mergeButton = page.locator('[data-testid="merge-next-button"]').first();
     await expect(mergeButton).toBeEnabled({ timeout: 5000 });
     await mergeButton.click();
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(5000);
 
-    await expect(page.locator('text=Regions (1)').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Regions (1)').first()).toBeVisible({ timeout: 20000 });
     console.log('✅ Merge reduced region count to 1');
   });
 });

--- a/tests/e2e/issues.spec.ts
+++ b/tests/e2e/issues.spec.ts
@@ -180,7 +180,7 @@ testWithAccount('owner').describe('Comment round-trip on an issue', () => {
     if (editorContext) await editorContext.close().catch(() => {});
   });
 
-  testWithAccount('owner')('owner posts comment; editor sees it after reload', async ({ page }) => {
+  testWithAccount('owner')('owner posts comment; editor sees it after reload (comment round-trip)', async ({ page }) => {
     // Owner creates region + issue
     await page.goto(`/transcribe-edit/${transcriptionId}`);
     await page.waitForLoadState('networkidle');
@@ -234,5 +234,168 @@ testWithAccount('owner').describe('Comment round-trip on an issue', () => {
     console.log('✅ Owner comment visible to editor via commentsByTranscription / listComments resolver');
 
     await editorPage.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue resolve toggle
+// ---------------------------------------------------------------------------
+testWithAccount('owner').describe('Issue resolve toggle', () => {
+  let transcriptionId: string;
+  let title: string;
+
+  testWithAccount('owner').beforeEach(async ({ page }) => {
+    const result = await createTestTranscription(page);
+    transcriptionId = result.transcriptionId;
+    title = result.title;
+  });
+
+  testWithAccount('owner').afterEach(async ({ page }) => {
+    await deleteTestTranscription(page, transcriptionId, title);
+  });
+
+  testWithAccount('owner')('owner can resolve an issue; resolved state persists after reload', async ({ page }) => {
+    await createRegionAndIssue(page);
+    await expect(page.locator('text=Issues (1)').first()).toBeVisible({ timeout: 10000 });
+
+    // Open the issue details dialog
+    const issueItem = page.locator('[data-testid="issue-item-open-dialog"]').first();
+    await expect(issueItem).toBeVisible();
+    await issueItem.click();
+    await page.waitForTimeout(1000);
+
+    // Click resolve — the badge should flip to RESOLVED
+    const resolveBtn = page.locator('[data-testid="issue-resolve-toggle"]').first();
+    await expect(resolveBtn).toBeVisible({ timeout: 5000 });
+    await resolveBtn.click();
+    await page.waitForTimeout(2000);
+
+    await expect(page.locator('text=RESOLVED').first()).toBeVisible({ timeout: 5000 });
+    console.log('✅ Issue resolved; RESOLVED badge visible');
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+
+    // Reload and verify resolved state persists
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const regionItem = page.locator('[data-testid*="regionitem"]').first();
+    await expect(regionItem).toBeVisible({ timeout: 15000 });
+    await regionItem.click();
+    await page.waitForTimeout(1000);
+
+    await expect(page.locator('text=Issues (1)').first()).toBeVisible({ timeout: 10000 });
+
+    const issueItemReloaded = page.locator('[data-testid="issue-item-open-dialog"]').first();
+    await expect(issueItemReloaded).toBeVisible();
+    await issueItemReloaded.click();
+    await page.waitForTimeout(1000);
+
+    await expect(page.locator('text=RESOLVED').first()).toBeVisible({ timeout: 5000 });
+    console.log('✅ Resolved state persisted after hard reload');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue delete
+// ---------------------------------------------------------------------------
+testWithAccount('owner').describe('Issue delete', () => {
+  let transcriptionId: string;
+  let title: string;
+
+  testWithAccount('owner').beforeEach(async ({ page }) => {
+    const result = await createTestTranscription(page);
+    transcriptionId = result.transcriptionId;
+    title = result.title;
+  });
+
+  testWithAccount('owner').afterEach(async ({ page }) => {
+    await deleteTestTranscription(page, transcriptionId, title);
+  });
+
+  testWithAccount('owner')('owner can delete an issue; it is removed from IssuesPanel after reload', async ({ page }) => {
+    await createRegionAndIssue(page);
+    await expect(page.locator('text=Issues (1)').first()).toBeVisible({ timeout: 10000 });
+
+    const issueItem = page.locator('[data-testid="issue-item-open-dialog"]').first();
+    await expect(issueItem).toBeVisible();
+    await issueItem.click();
+    await page.waitForTimeout(1000);
+
+    page.once('dialog', async (dialog) => dialog.accept());
+
+    const deleteBtn = page.locator('[data-testid="issue-delete-button"]').first();
+    await expect(deleteBtn).toBeVisible({ timeout: 5000 });
+    await deleteBtn.click();
+    await page.waitForTimeout(2000);
+
+    await expect(page.locator('text=Issues (0)').first()).toBeVisible({ timeout: 10000 });
+    console.log('✅ Issue deleted; Issues (0) visible immediately');
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const regionItem = page.locator('[data-testid*="regionitem"]').first();
+    await expect(regionItem).toBeVisible({ timeout: 15000 });
+    await regionItem.click();
+    await page.waitForTimeout(1000);
+
+    await expect(page.locator('text=Issues (0)').first()).toBeVisible({ timeout: 10000 });
+    console.log('✅ Issue deletion persisted after hard reload');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Comment delete
+// ---------------------------------------------------------------------------
+testWithAccount('owner').describe('Comment delete', () => {
+  let transcriptionId: string;
+  let title: string;
+
+  testWithAccount('owner').beforeEach(async ({ page }) => {
+    const result = await createTestTranscription(page);
+    transcriptionId = result.transcriptionId;
+    title = result.title;
+  });
+
+  testWithAccount('owner').afterEach(async ({ page }) => {
+    await deleteTestTranscription(page, transcriptionId, title);
+  });
+
+  testWithAccount('owner')('owner can delete a comment; it is removed immediately', async ({ page }) => {
+    await createRegionAndIssue(page);
+    await expect(page.locator('text=Issues (1)').first()).toBeVisible({ timeout: 10000 });
+
+    const issueItem = page.locator('[data-testid="issue-item-open-dialog"]').first();
+    await expect(issueItem).toBeVisible();
+    await issueItem.click();
+    await page.waitForTimeout(1000);
+
+    const commentInput = page.locator('[data-testid="comment-input"]').first();
+    await expect(commentInput).toBeVisible({ timeout: 5000 });
+    const commentText = `delete me ${Date.now()}`;
+    await commentInput.fill(commentText);
+
+    const submitBtn = page.locator('[data-testid="submit-comment"]').first();
+    await expect(submitBtn).toBeEnabled();
+    await submitBtn.click();
+    await page.waitForTimeout(2000);
+
+    const commentItem = page.locator(`[data-testid="comment-item"]:has-text("${commentText}")`).first();
+    await expect(commentItem).toBeVisible({ timeout: 5000 });
+    console.log('✅ Comment posted and visible');
+
+    page.once('dialog', async (dialog) => dialog.accept());
+
+    const deleteCommentBtn = commentItem.locator('[data-testid="comment-delete-button"]').first();
+    await expect(deleteCommentBtn).toBeVisible({ timeout: 5000 });
+    await deleteCommentBtn.click();
+    await page.waitForTimeout(2000);
+
+    await expect(
+      page.locator(`[data-testid="comment-item"]:has-text("${commentText}")`)
+    ).toHaveCount(0, { timeout: 5000 });
+    console.log('✅ Comment deleted and removed from dialog');
   });
 });

--- a/tests/e2e/issues.spec.ts
+++ b/tests/e2e/issues.spec.ts
@@ -285,15 +285,23 @@ testWithAccount('owner').describe('Issue resolve toggle', () => {
     await regionItem.click();
     await page.waitForTimeout(1000);
 
-    await expect(page.locator('text=Issues (1)').first()).toBeVisible({ timeout: 10000 });
+    // Resolved issues are hidden by default; the toggle "Show resolved issues (1)"
+    // confirms the resolved state persisted
+    const showResolvedToggle = page.locator('text=Show resolved issues (1)').first();
+    await expect(showResolvedToggle).toBeVisible({ timeout: 10000 });
+    console.log('✅ "Show resolved issues (1)" visible — resolved state persisted after reload');
+
+    // Click the toggle to reveal the resolved issue and verify the RESOLVED badge
+    await showResolvedToggle.click();
+    await page.waitForTimeout(500);
 
     const issueItemReloaded = page.locator('[data-testid="issue-item-open-dialog"]').first();
-    await expect(issueItemReloaded).toBeVisible();
+    await expect(issueItemReloaded).toBeVisible({ timeout: 5000 });
     await issueItemReloaded.click();
     await page.waitForTimeout(1000);
 
     await expect(page.locator('text=RESOLVED').first()).toBeVisible({ timeout: 5000 });
-    console.log('✅ Resolved state persisted after hard reload');
+    console.log('✅ RESOLVED badge visible after toggling resolved issues on');
   });
 });
 

--- a/tests/e2e/list-management.spec.ts
+++ b/tests/e2e/list-management.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Transcription list management coverage
+ *
+ * - Title search/filter shows only matching rows and clears correctly
+ * - Sort select can be changed without breaking the list
+ * - Delete via the list trash button removes the row from the list
+ *
+ * All tests are owner-pinned; a transcription is created in beforeEach
+ * and cleaned up in afterEach as a safety net (delete test handles its own cleanup).
+ */
+import { testWithAccount, expect } from '../../playwright/fixtures';
+import { createTestTranscription, deleteTestTranscription } from './helpers';
+
+testWithAccount('owner').describe('Transcription list management', () => {
+  let transcriptionId: string;
+  let title: string;
+
+  testWithAccount('owner').beforeEach(async ({ page }) => {
+    const result = await createTestTranscription(page);
+    transcriptionId = result.transcriptionId;
+    title = result.title;
+    // Navigate to the list after creation
+    await page.goto('/transcribe-list');
+    await page.waitForLoadState('networkidle');
+  });
+
+  testWithAccount('owner').afterEach(async ({ page }) => {
+    if (transcriptionId && title) {
+      await deleteTestTranscription(page, transcriptionId, title);
+    }
+    transcriptionId = '';
+    title = '';
+  });
+
+  testWithAccount('owner')('search filter shows only matching rows and clears correctly', async ({ page }) => {
+    // The transcription created in beforeEach should be visible
+    const titleRow = page.locator('[data-testid="transcription-list-item-title-row"]').filter({ hasText: title }).first();
+    await expect(titleRow).toBeVisible({ timeout: 15000 });
+
+    // Type the unique title into the search input
+    const searchInput = page.locator('[data-testid="transcription-search-input"]').first();
+    await expect(searchInput).toBeVisible();
+    await searchInput.fill(title);
+    await page.waitForTimeout(500);
+
+    // The matching row should still be visible
+    await expect(titleRow).toBeVisible();
+
+    // The results count text should confirm 1 match
+    await expect(page.locator('text=1 transcription').first()).toBeVisible({ timeout: 5000 });
+    console.log('✅ Search filter shows 1 matching result');
+
+    // Clear the search — the row should still be visible and count recovers
+    await searchInput.clear();
+    await page.waitForTimeout(500);
+    await expect(titleRow).toBeVisible();
+    console.log('✅ Search cleared; row visible again');
+  });
+
+  testWithAccount('owner')('sort select can be changed without breaking the list', async ({ page }) => {
+    const sortSelect = page.locator('[data-testid="transcription-sort-select"]').first();
+    await expect(sortSelect).toBeVisible();
+
+    // Change to title descending and assert list still renders
+    await sortSelect.selectOption('title-desc');
+    await page.waitForTimeout(500);
+    const titleRow = page.locator('[data-testid="transcription-list-item-title-row"]').first();
+    await expect(titleRow).toBeVisible({ timeout: 5000 });
+    console.log('✅ Sort changed to title-desc; list still renders');
+
+    // Change to title ascending
+    await sortSelect.selectOption('title-asc');
+    await page.waitForTimeout(500);
+    await expect(titleRow).toBeVisible({ timeout: 5000 });
+    console.log('✅ Sort changed to title-asc; list still renders');
+  });
+
+  testWithAccount('owner')('delete via list trash button removes the row', async ({ page }) => {
+    const titleRow = page.locator('[data-testid="transcription-list-item-title-row"]').filter({ hasText: title }).first();
+    await expect(titleRow).toBeVisible({ timeout: 15000 });
+
+    // Click the trash icon in the desktop row
+    const deleteBtn = titleRow.locator('[data-testid="transcription-delete-button"]').first();
+    await expect(deleteBtn).toBeVisible();
+    await deleteBtn.click();
+    await page.waitForTimeout(500);
+
+    // Fill the confirmation input and confirm
+    const confirmInput = page.locator('[data-testid="delete-confirm-input"]').first();
+    await expect(confirmInput).toBeVisible({ timeout: 5000 });
+    await confirmInput.fill('delete forever');
+
+    const deleteForeverBtn = page.locator('[data-testid="delete-forever-button"]').first();
+    await expect(deleteForeverBtn).toBeVisible();
+    await deleteForeverBtn.click();
+    await page.waitForTimeout(3000);
+
+    // Row should no longer be visible
+    await expect(
+      page.locator('[data-testid="transcription-list-item-title-row"]').filter({ hasText: title })
+    ).toHaveCount(0, { timeout: 10000 });
+    console.log('✅ Transcription row removed from list after deletion');
+
+    // Mark as cleaned up so afterEach skips
+    transcriptionId = '';
+    title = '';
+  });
+});

--- a/tests/e2e/list-management.spec.ts
+++ b/tests/e2e/list-management.spec.ts
@@ -76,11 +76,12 @@ testWithAccount('owner').describe('Transcription list management', () => {
   });
 
   testWithAccount('owner')('delete via list trash button removes the row', async ({ page }) => {
-    const titleRow = page.locator('[data-testid="transcription-list-item-title-row"]').filter({ hasText: title }).first();
-    await expect(titleRow).toBeVisible({ timeout: 15000 });
+    // Scope to the card container (parent of both the title row and the delete button)
+    const card = page.locator('[data-testid="transcription-list-item"]').filter({ hasText: title }).first();
+    await expect(card).toBeVisible({ timeout: 15000 });
 
     // Click the trash icon in the desktop row
-    const deleteBtn = titleRow.locator('[data-testid="transcription-delete-button"]').first();
+    const deleteBtn = card.locator('[data-testid="transcription-delete-button"]').first();
     await expect(deleteBtn).toBeVisible();
     await deleteBtn.click();
     await page.waitForTimeout(500);


### PR DESCRIPTION
resolve #307

Added four focused e2e specs covering flows that had no test coverage: editor text persistence, list search/filter/sort, issue and comment lifecycle (resolve, delete), and Language Database search/navigation. Where stable selectors were absent, `data-testid` attributes were added to the production components. A `COVERAGE.md` matrix now tracks which core flows are exercised so gaps stay visible going forward.

### Testing
All four specs — `editor-text.spec.ts`, `list-management.spec.ts`, `issues.spec.ts`, `database.spec.ts` — passed against staging. `npm run test`, `npm run lint`, and `npm run build` all pass.