### PR TITLE
Fix shared transcription load failure blocking entire transcription list

### DIFF
--- a/src/services/transcriptionService.test.ts
+++ b/src/services/transcriptionService.test.ts
@@ -926,6 +926,48 @@ describe('TranscriptionService', () => {
     });
   });
 
+  describe('performSync resilience — shared load failures (issue #303)', () => {
+    beforeEach(() => {
+      (currentUser as jest.Mock).mockReturnValue({ userId: 'test-user-id', username: 'test@example.com' });
+      (transcriptionStorage.getLastSyncedAt as jest.Mock).mockResolvedValue(null); // first-sync path
+      mockGraphqlClient.graphql.mockResolvedValue({
+        data: {
+          transcriptionsByAuthor: {
+            items: [{ id: 'owned-1', title: 'My Transcription', author: 'test-user-id' }],
+          },
+        },
+      });
+    });
+
+    it('should resolve with owned transcriptions when shared load fails with API error', async () => {
+      const { getMyInvites } = require('./inviteService');
+      // Simulate stale client where 'invite' REST API is not in Amplify config.
+      // Use two once-rejections to cover both performSync call sites in loadAll
+      // (primary sync and the fallback). This proves the fix prevents the error
+      // from surfacing as a blocking failure regardless of which code path runs.
+      (getMyInvites as jest.Mock)
+        .mockRejectedValueOnce(new Error('API name is invalid.'))
+        .mockRejectedValueOnce(new Error('API name is invalid.'));
+
+      // Before the fix this rejects; after the fix it resolves with owned transcriptions
+      await expect(loadAll()).resolves.toBeDefined();
+    });
+
+    it('should still merge owned and shared when both succeed', async () => {
+      const { getMyInvites } = require('./inviteService');
+      // Happy path is unaffected by the resilience change
+      (getMyInvites as jest.Mock).mockResolvedValueOnce({
+        invites: [],
+        total: 0,
+        filters: { userEmail: 'test@example.com', transcriptionId: null, inviteId: null }
+      });
+
+      await expect(loadAll()).resolves.toBeDefined();
+      expect(getMyInvites).toHaveBeenCalled();
+      expect(mockGraphqlClient.graphql).toHaveBeenCalled();
+    });
+  });
+
   describe('clearTranscriptionCache', () => {
     it('delegates to transcriptionStorage.clearCache', async () => {
       await clearTranscriptionCache();

--- a/src/services/transcriptionService.ts
+++ b/src/services/transcriptionService.ts
@@ -998,9 +998,20 @@ const performSync = async (sinceTimestamp?: string): Promise<TranscriptionModel[
     }
     console.debug(`📝 Loaded ${ownedTranscriptions.length} owned transcriptions`);
     
-    // Load shared transcriptions via invites (need email for invite lookup)
-    const sharedTranscriptions: TranscriptionModel[] = await loadSharedTranscriptions(user.username, sinceTimestamp);
-    console.debug(`🤝 Loaded ${sharedTranscriptions.length} shared transcriptions`);
+    // Load shared transcriptions via invites (need email for invite lookup).
+    // Wrapped in try/catch so a shared-load failure (e.g. stale client with
+    // unregistered REST API — see issue #303) does not blank the owned list.
+    let sharedTranscriptions: TranscriptionModel[] = [];
+    try {
+      sharedTranscriptions = await loadSharedTranscriptions(user.username, sinceTimestamp);
+      console.debug(`🤝 Loaded ${sharedTranscriptions.length} shared transcriptions`);
+    } catch (sharedError) {
+      // Log build hash + service-worker URL to help diagnose stale-bundle issues in the wild
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const buildHash = (globalThis as any).__BUILD_HASH__ ?? 'unknown';
+      const swUrl = typeof navigator !== 'undefined' ? (navigator.serviceWorker?.controller?.scriptURL ?? 'none') : 'n/a';
+      console.warn(`⚠️ Shared transcription load failed — owned list unaffected (build=${buildHash}, sw=${swUrl}):`, sharedError);
+    }
 
     // Combine and deduplicate (in case user has both ownership and invite access)
     const allTranscriptions = new Map<string, TranscriptionModel>();


### PR DESCRIPTION
resolve #303

A shared-transcription load failure (e.g. a stale PWA bundle calling an unregistered REST API, which surfaced as "API name is invalid") was propagating through `performSync` and blanking the entire transcription list. The shared-load call is now isolated in its own try/catch so a failure degrades gracefully — owned transcriptions still render, and the error is logged with build hash and service worker URL to help identify stale-bundle occurrences in production.

### Testing
- Added unit tests in `transcriptionService.test.ts` covering the shared-load failure path.
- `npm run test` (1993 tests) and `npm run lint` pass.